### PR TITLE
Add: `ReportingConsistency` Plugin

### DIFF
--- a/tests/plugins/test_reporting_consistency.py
+++ b/tests/plugins/test_reporting_consistency.py
@@ -17,8 +17,8 @@
 
 from pathlib import Path
 
-from naslinter.plugin import LinterError
-from naslinter.plugins.reporting_consistency import CheckReportingConsistency
+from troubadix.plugin import LinterError
+from troubadix.plugins.reporting_consistency import CheckReportingConsistency
 from tests.plugins import PluginTestCase
 
 

--- a/tests/plugins/test_reporting_consistency.py
+++ b/tests/plugins/test_reporting_consistency.py
@@ -1,0 +1,146 @@
+#  Copyright (c) 2022 Greenbone Networks GmbH
+#
+#  SPDX-License-Identifier: GPL-3.0-or-later
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+from naslinter.plugin import LinterError
+from naslinter.plugins.reporting_consistency import CheckReportingConsistency
+from tests.plugins import PluginTestCase
+
+
+class CheckReportingConsistencyTestCase(PluginTestCase):
+    def test_ok(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"0.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            "log_message('Test');\n"
+        )
+
+        results = list(
+            CheckReportingConsistency.run(
+                nasl_file=nasl_file,
+                file_content=content,
+                tag_pattern=self.tag_pattern,
+                special_tag_pattern=self.special_tag_pattern,
+            )
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_ok2(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            "security_message( port:port, data:'It was possible to get the "
+            "csrf token `' + token[1] + '` via a jsonp request to: ' + "
+            "http_report_vuln_url( port:port, url:url, url_only:TRUE ) );\n"
+        )
+
+        results = list(
+            CheckReportingConsistency.run(
+                nasl_file=nasl_file,
+                file_content=content,
+                tag_pattern=self.tag_pattern,
+                special_tag_pattern=self.special_tag_pattern,
+            )
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_fail(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"0.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            "security_message( port:port, data:'It was possible to get the "
+            "csrf token `' + token[1] + '` via a jsonp request to: ' + "
+            "http_report_vuln_url( port:port, url:url, url_only:TRUE ) );\n"
+        )
+
+        results = list(
+            CheckReportingConsistency.run(
+                nasl_file=nasl_file,
+                file_content=content,
+                tag_pattern=self.tag_pattern,
+                special_tag_pattern=self.special_tag_pattern,
+            )
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "Tag cvss_base is 0.0 use report function log_message",
+            results[0].message,
+        )
+
+    def test_fail2(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            "security_message( port:port, data:'It was possible to get the "
+            "csrf token `' + token[1] + '` via a jsonp request to: ' + "
+            "http_report_vuln_url( port:port, url:url, url_only:TRUE ) );\n"
+        )
+
+        results = list(
+            CheckReportingConsistency.run(
+                nasl_file=nasl_file,
+                file_content=content,
+                tag_pattern=self.tag_pattern,
+                special_tag_pattern=self.special_tag_pattern,
+            )
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "VT/Include has no cvss_base tag",
+            results[0].message,
+        )
+
+    def test_fail3(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"5.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            "log_message( port:port, data:'It was possible to get the "
+            "csrf token `' + token[1] + '` via a jsonp request to: ' + "
+            "http_report_vuln_url( port:port, url:url, url_only:TRUE ) );\n"
+        )
+
+        results = list(
+            CheckReportingConsistency.run(
+                nasl_file=nasl_file,
+                file_content=content,
+                tag_pattern=self.tag_pattern,
+                special_tag_pattern=self.special_tag_pattern,
+            )
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "Tag cvss_base is not 0.0 use report function security_message",
+            results[0].message,
+        )

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -44,6 +44,7 @@ from .newlines import CheckNewlines
 from .openvas_lint import CheckOpenvasLint
 from .overlong_script_tags import CheckOverlongScriptTags
 from .prod_svc_detect_in_vulnvt import CheckProdSvcDetectInVulnvt
+from .reporting_consistency import CheckReportingConsistency
 from .risk_factor import CheckRiskFactor
 from .script_category import CheckScriptCategory
 from .script_copyright import CheckScriptCopyright
@@ -91,6 +92,7 @@ _NASL_ONLY_PLUGINS = [
     CheckOpenvasLint,
     CheckOverlongScriptTags,
     CheckProdSvcDetectInVulnvt,
+    CheckReportingConsistency,
     CheckRiskFactor,
     CheckScriptCategory,
     CheckScriptCopyright,

--- a/troubadix/plugins/reporting_consistency.py
+++ b/troubadix/plugins/reporting_consistency.py
@@ -50,6 +50,9 @@ class CheckReportingConsistency(FileContentPlugin):
         # Check check_cve_format looks close!
         # Removed script_id(...) and SCRIPT_OID=... deprecated!
 
+        if nasl_file.suffix == ".inc":
+            return
+
         report_function = re.compile(r"log_message|security_message").search(
             file_content
         )

--- a/troubadix/plugins/reporting_consistency.py
+++ b/troubadix/plugins/reporting_consistency.py
@@ -1,0 +1,80 @@
+#  Copyright (c) 2022 Greenbone Networks GmbH
+#
+#  SPDX-License-Identifier: GPL-3.0-or-later
+#
+#  This program is free software: you can redistribute it and/or modify
+#  Copyright (c) 2022 Greenbone Networks GmbH
+#
+#  SPDX-License-Identifier: GPL-3.0-or-later
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import re
+
+from pathlib import Path
+from typing import Iterator, OrderedDict
+
+from troubadix.helper.patterns import ScriptTag
+from troubadix.plugin import LinterError, FileContentPlugin, LinterResult
+
+
+class CheckReportingConsistency(FileContentPlugin):
+    name = "check_reporting_consistency"
+
+    @staticmethod
+    def run(
+        nasl_file: Path,
+        file_content: str,
+        *,
+        tag_pattern: OrderedDict[str, re.Pattern],
+        special_tag_pattern: OrderedDict[str, re.Pattern],
+    ) -> Iterator[LinterResult]:
+        """This script checks the consistency between log_message,
+        security_message reporting function and
+        the cvss base value.
+        """
+        del special_tag_pattern
+
+        # Check check_security_messages looks close!
+        # Check check_log_messages looks close!
+        # Check check_cve_format looks close!
+        # Removed script_id(...) and SCRIPT_OID=... deprecated!
+
+        report_function = re.compile(r"log_message|security_message").search(
+            file_content
+        )
+        if not report_function:
+            # We can't do anything about this one, skipping
+            return
+
+        cvss_base = tag_pattern[ScriptTag.CVSS_BASE.value].search(file_content)
+
+        if not cvss_base:
+            yield LinterError("VT/Include has no cvss_base tag")
+            return
+
+        if (
+            report_function.group() == "log_message"
+            and cvss_base.group("value") != "0.0"
+        ):
+            yield LinterError(
+                "Tag cvss_base is not 0.0 use report function security_message"
+            )
+
+        if (
+            report_function.group() == "security_message"
+            and cvss_base.group("value") == "0.0"
+        ):
+            yield LinterError(
+                "Tag cvss_base is 0.0 use report function log_message"
+            )

--- a/troubadix/plugins/reporting_consistency.py
+++ b/troubadix/plugins/reporting_consistency.py
@@ -1,24 +1,20 @@
-#  Copyright (c) 2022 Greenbone Networks GmbH
+# Copyright (C) 2022 Greenbone Networks GmbH
 #
-#  SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-#  This program is free software: you can redistribute it and/or modify
-#  Copyright (c) 2022 Greenbone Networks GmbH
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#  SPDX-License-Identifier: GPL-3.0-or-later
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#  This program is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import re
 
 from pathlib import Path
@@ -44,11 +40,6 @@ class CheckReportingConsistency(FileContentPlugin):
         the cvss base value.
         """
         del special_tag_pattern
-
-        # Check check_security_messages looks close!
-        # Check check_log_messages looks close!
-        # Check check_cve_format looks close!
-        # Removed script_id(...) and SCRIPT_OID=... deprecated!
 
         if nasl_file.suffix == ".inc":
             return


### PR DESCRIPTION
**What**: Check-reporting-consistency plugin from https://gitlab.greenbone.net/production/gsf-qa/-/blob/master/nvt-qa-scripts/steps/58-check-reporting-consistency.py

This is a version without the openvas generated SQLite database as previously requested.
It really looks similar to check_security_messages, check_cve_format and check_cve_format!
Since I don't really know NASL scripting, i recommend generating this DB at the moment we have a pre-plugin loader in the linter.
Maybe there are steps in DB creation where "cvss_base tags" be merged from various .nasl .inc files for an OID or something else.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

DEVOPS-128

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
