### PR TITLE
Change: Add argument `--update-date` to run Plugin `UpdateModificationDate`

### DIFF
--- a/tests/test_argparser.py
+++ b/tests/test_argparser.py
@@ -59,6 +59,7 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -92,6 +93,7 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -124,6 +126,7 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=True,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -149,6 +152,7 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -158,7 +162,6 @@ class TestArgparsing(unittest.TestCase):
             "troubadix",
             "--include-tests",
             "CheckBadwords",
-            "UpdateModificationDate",
         ]
 
         parsed_args = parse_args()
@@ -176,9 +179,10 @@ class TestArgparsing(unittest.TestCase):
             include_patterns=None,
             exclude_patterns=None,
             excluded_plugins=None,
-            included_plugins=["CheckBadwords", "UpdateModificationDate"],
+            included_plugins=["CheckBadwords"],
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -188,7 +192,6 @@ class TestArgparsing(unittest.TestCase):
             "troubadix",
             "--exclude-tests",
             "CheckBadwords",
-            "UpdateModificationDate",
         ]
 
         parsed_args = parse_args()
@@ -205,10 +208,11 @@ class TestArgparsing(unittest.TestCase):
             non_recursive=False,
             include_patterns=None,
             exclude_patterns=None,
-            excluded_plugins=["CheckBadwords", "UpdateModificationDate"],
+            excluded_plugins=["CheckBadwords"],
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -235,6 +239,7 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -279,6 +284,7 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
@@ -312,11 +318,12 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count(),
+            update_date=False,
         )
 
         self.assertEqual(parsed_args, expected_args)
 
-    def test_parse_min_cpu(self):
+    def test_parse_min_cpu_update_date(self):
         sys.argv = [
             "troubadix",
             "-f",
@@ -324,6 +331,7 @@ class TestArgparsing(unittest.TestCase):
             "troubadix/*",
             "-j",
             "-1337",
+            "--update-date",
         ]
         expcected_dirs = [Path.cwd()]
 
@@ -345,6 +353,7 @@ class TestArgparsing(unittest.TestCase):
             included_plugins=None,
             skip_duplicated_oids=False,
             n_jobs=cpu_count() // 2,
+            update_date=True,
         )
 
         self.assertEqual(parsed_args, expected_args)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -24,7 +24,7 @@ from pontos.terminal import _set_terminal
 from pontos.terminal.terminal import Terminal
 
 from troubadix.plugin import LinterError, LinterResult
-from troubadix.plugins import _NASL_ONLY_PLUGINS
+from troubadix.plugins import _PLUGINS
 from troubadix.runner import Runner, TroubadixException
 
 _here = Path(__file__).parent
@@ -39,7 +39,7 @@ class TestRunner(unittest.TestCase):
     def test_runner_with_all_plugins(self):
         runner = Runner(n_jobs=1, term=self._term)
 
-        plugins = _NASL_ONLY_PLUGINS
+        plugins = _PLUGINS
 
         for plugin in runner.plugins.plugins:
             self.assertIn(plugin, plugins)
@@ -48,11 +48,10 @@ class TestRunner(unittest.TestCase):
         excluded_plugins = [
             "CheckBadwords",
             "CheckCopyRightYearPlugin",
-            "UpdateModificationDate",
         ]
         included_plugins = [
             plugin.__name__
-            for plugin in _NASL_ONLY_PLUGINS
+            for plugin in _PLUGINS
             if plugin.__name__ not in excluded_plugins
         ]
         runner = Runner(
@@ -79,16 +78,13 @@ class TestRunner(unittest.TestCase):
             self.assertIn(plugin.__name__, included_plugins)
 
     def test_runner_run_ok(self):
-        included_plugins = [
-            "UpdateModificationDate",
-        ]
         nasl_file = _here / "plugins" / "test.nasl"
         content = nasl_file.read_text(encoding="latin1")
 
         runner = Runner(
             n_jobs=1,
             term=self._term,
-            included_plugins=included_plugins,
+            update_date=True,
         )
 
         results = runner.check_file(nasl_file)
@@ -110,16 +106,13 @@ class TestRunner(unittest.TestCase):
         nasl_file.write_text(content, encoding="latin1")
 
     def test_runner_run_error(self):
-        included_plugins = [
-            "UpdateModificationDate",
-        ]
         nasl_file = _here / "plugins" / "fail.nasl"
         content = nasl_file.read_text(encoding="latin1")
 
         runner = Runner(
             n_jobs=1,
             term=self._term,
-            included_plugins=included_plugins,
+            update_date=True,
         )
 
         results = runner.check_file(nasl_file)
@@ -141,16 +134,13 @@ class TestRunner(unittest.TestCase):
         )
 
     def test_runner_run_fail_with_debug(self):
-        included_plugins = [
-            "UpdateModificationDate",
-        ]
         nasl_file = _here / "plugins" / "fail.nasl"
         content = nasl_file.read_text(encoding="latin1")
 
         runner = Runner(
             n_jobs=1,
             term=self._term,
-            included_plugins=included_plugins,
+            update_date=True,
             debug=True,
         )
 
@@ -174,16 +164,13 @@ class TestRunner(unittest.TestCase):
         )
 
     def test_runner_run_changed_without_debug(self):
-        included_plugins = [
-            "UpdateModificationDate",
-        ]
         nasl_file = _here / "plugins" / "test.nasl"
         content = nasl_file.read_text(encoding="latin1")
 
         runner = Runner(
             n_jobs=1,
             term=self._term,
-            included_plugins=included_plugins,
+            update_date=True,
         )
 
         with redirect_stdout(io.StringIO()) as f:

--- a/troubadix/argparser.py
+++ b/troubadix/argparser.py
@@ -118,13 +118,13 @@ def parse_args(
     what_group.add_argument(
         "--staged-only",
         action="store_true",
-        help=('Only run against files which are "staged/added" in git'),
+        help='Only run against files which are "staged/added" in git',
     )
 
     parser.add_argument(
         "--debug",
         action="store_true",
-        help=("Enables the DEBUG output"),
+        help="Enables the DEBUG output",
     )
 
     parser.add_argument(
@@ -182,6 +182,16 @@ def parse_args(
             "Allows to exclude tests from this lint. "
             "All tests excluding the given will run. "
             "Valid as CamelCase and snake_case."
+        ),
+    )
+
+    tests_group.add_argument(
+        "--update-date",
+        action="store_true",
+        help=(
+            "Run troubadix in update modification_date and "
+            "script_version mode. Attention: This will modify all "
+            "passed files."
         ),
     )
 

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -67,7 +67,7 @@ from .valid_oid import CheckValidOID
 from .valid_script_tag_names import CheckValidScriptTagNames
 from .vt_placement import CheckVTPlacement
 
-_NASL_ONLY_PLUGINS = [
+_PLUGINS = [
     CheckBadwords,
     CheckCVEFormat,
     CheckCVSSFormat,
@@ -110,10 +110,6 @@ _NASL_ONLY_PLUGINS = [
     CheckValidOID,
     CheckValidScriptTagNames,
     CheckWrongSetGetKBCalls,
-    UpdateModificationDate,
-]
-
-_PLUGINS = [
     CheckEncoding,
     CheckTabs,
 ]
@@ -124,19 +120,23 @@ class Plugins:
         self,
         excluded_plugins: List[str] = None,
         included_plugins: List[str] = None,
+        update_date: bool = False,
     ) -> None:
-        self.plugins = _NASL_ONLY_PLUGINS
+        if update_date:
+            self.plugins = [UpdateModificationDate]
+            return
+        self.plugins = _PLUGINS
         if excluded_plugins:
             self.plugins = [
                 plugin
-                for plugin in _NASL_ONLY_PLUGINS
+                for plugin in _PLUGINS
                 if plugin.__name__ not in excluded_plugins
                 and plugin.name not in excluded_plugins
             ]
         if included_plugins:
             self.plugins = [
                 plugin
-                for plugin in _NASL_ONLY_PLUGINS
+                for plugin in _PLUGINS
                 if plugin.__name__ in included_plugins
                 or plugin.name in included_plugins
             ]

--- a/troubadix/runner.py
+++ b/troubadix/runner.py
@@ -82,10 +82,13 @@ class Runner:
         *,
         excluded_plugins: List[str] = None,
         included_plugins: List[str] = None,
+        update_date: bool = False,
         debug: bool = False,
         statistic: bool = True,
     ) -> None:
-        self.plugins = Plugins(excluded_plugins, included_plugins)
+        self.plugins = Plugins(
+            excluded_plugins, included_plugins, update_date=update_date
+        )
         self._term = term
         self._n_jobs = n_jobs
         self.debug = debug

--- a/troubadix/troubadix.py
+++ b/troubadix/troubadix.py
@@ -112,6 +112,7 @@ def main(args=None):
         term=term,
         excluded_plugins=parsed_args.excluded_plugins,
         included_plugins=parsed_args.included_plugins,
+        update_date=parsed_args.update_date,
         debug=parsed_args.debug,
         statistic=True if not parsed_args.no_statistic else False,
     )


### PR DESCRIPTION
**What**:

* Detach the Plugin `UpdateModificationDate`
* This plugin is only used to update the modification date and script version, not for general Linting/QA, thus it should not run on default
* Run this plugin with `--update-date` parameter   

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
