### PR TITLE
Allow for using plugin name in include and exclude args

### DIFF
--- a/troubadix/argparser.py
+++ b/troubadix/argparser.py
@@ -169,7 +169,7 @@ def parse_args(
         dest="included_plugins",
         help=(
             "Allows to choose which tests should be run in this lint. "
-            "Only the given tests will run."
+            "Only the given tests will run. Valid as CamelCase and snake_case."
         ),
     )
 
@@ -180,7 +180,8 @@ def parse_args(
         dest="excluded_plugins",
         help=(
             "Allows to exclude tests from this lint. "
-            "All tests excluding the given will run."
+            "All tests excluding the given will run. "
+            "Valid as CamelCase and snake_case."
         ),
     )
 

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -131,12 +131,14 @@ class Plugins:
                 plugin
                 for plugin in _NASL_ONLY_PLUGINS
                 if plugin.__name__ not in excluded_plugins
+                and plugin.name not in excluded_plugins
             ]
         if included_plugins:
             self.plugins = [
                 plugin
                 for plugin in _NASL_ONLY_PLUGINS
                 if plugin.__name__ in included_plugins
+                or plugin.name in included_plugins
             ]
 
     def __iter__(self) -> Iterable[Plugin]:


### PR DESCRIPTION
**What**:

In the console output only the plugin names not the plugin class names
are displayed. Therefore a user should be allowed to use this name for
excluding and including plugins in a run.

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
