### PR TITLE
Change: changed CheckTodoTbd to return Warning instead of Error

### DIFF
--- a/tests/plugins/test_todo_tbd.py
+++ b/tests/plugins/test_todo_tbd.py
@@ -17,7 +17,7 @@
 
 from pathlib import Path
 
-from troubadix.plugin import LinterError
+from troubadix.plugin import LinterWarning
 from troubadix.plugins import CheckTodoTbd
 
 from . import PluginTestCase
@@ -71,13 +71,13 @@ class CheckTodoTbdTestCase(PluginTestCase):
         )
         self.assertEqual(len(results), 2)
 
-        self.assertIsInstance(results[0], LinterError)
+        self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
             results[0].message,
         )
 
-        self.assertIsInstance(results[1], LinterError)
+        self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
             results[1].message,
@@ -99,13 +99,13 @@ class CheckTodoTbdTestCase(PluginTestCase):
         )
         self.assertEqual(len(results), 2)
 
-        self.assertIsInstance(results[0], LinterError)
+        self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
             results[0].message,
         )
 
-        self.assertIsInstance(results[1], LinterError)
+        self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
             results[1].message,
@@ -127,13 +127,13 @@ class CheckTodoTbdTestCase(PluginTestCase):
         )
         self.assertEqual(len(results), 2)
 
-        self.assertIsInstance(results[0], LinterError)
+        self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
             results[0].message,
         )
 
-        self.assertIsInstance(results[1], LinterError)
+        self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
             results[1].message,
@@ -155,19 +155,19 @@ class CheckTodoTbdTestCase(PluginTestCase):
         )
         self.assertEqual(len(results), 3)
 
-        self.assertIsInstance(results[0], LinterError)
+        self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
             results[0].message,
         )
 
-        self.assertIsInstance(results[1], LinterError)
+        self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
             results[1].message,
         )
 
-        self.assertIsInstance(results[2], LinterError)
+        self.assertIsInstance(results[2], LinterWarning)
         self.assertEqual(
             "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 4",
             results[2].message,

--- a/troubadix/plugins/todo_tbd.py
+++ b/troubadix/plugins/todo_tbd.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Iterable, Iterator
 
 from ..helper import is_ignore_file
-from ..plugin import LineContentPlugin, LinterError, LinterResult
+from ..plugin import LineContentPlugin, LinterWarning, LinterResult
 
 _IGNORE_FILES = [
     "gb_openvas",
@@ -48,7 +48,7 @@ class CheckTodoTbd(LineContentPlugin):
         for index, line in enumerate(lines, start=1):
             match = re.search("##? *(TODO|TBD|@todo):?", line)
             if match is not None:
-                yield LinterError(
+                yield LinterWarning(
                     f"VT {nasl_file} contains #TODO/TBD/@todo"
                     f" keywords at line {index}"
                 )


### PR DESCRIPTION
**What**:

changed CheckTodoTbd to return Warning instead of Error

**Why**:

<!-- Why are these changes necessary? -->

**How**:
- Return LinterWarning instead of of LinterError.
- Changed tests to check for instance of LinterWarning

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] Conventional commit message
- [ ] Documentation
