### PR TITLE
Change: Remove no longer existing directories from dependencies.py

### DIFF
--- a/troubadix/plugins/dependencies.py
+++ b/troubadix/plugins/dependencies.py
@@ -89,8 +89,6 @@ class CheckDependencies(FileContentPlugin):
                             or dep[:7] == "Policy/"
                             or dep[:11] == "gsf/PCIDSS/"
                             or dep[:11] == "gsf/Policy/"
-                            or dep[:4] == "gcf/"
-                            or dep[:9] == "nmap_nse/"
                         ):
                             yield LinterWarning(
                                 f"The script dependency {dep} is within "


### PR DESCRIPTION
They are gone from the VTs structure (all files got moved into the /attic) folder so the checks can be removed now.