### PR TITLE
Fix: Raise VALUE_LIMIT to 3000 as used in the original overlong script tags step

### DIFF
--- a/troubadix/plugins/overlong_script_tags.py
+++ b/troubadix/plugins/overlong_script_tags.py
@@ -24,7 +24,7 @@ from troubadix.helper import is_ignore_file
 from ..plugin import LineContentPlugin, LinterError, LinterResult
 
 # Arbitrary limit adopted from original step
-VALUE_LIMIT = 1000
+VALUE_LIMIT = 3000
 
 IGNORE_FILES = [
     "gb_nmap6_",


### PR DESCRIPTION
In the original code the following was used / defined:

```
        # Max amount of allowed chars for each tag
        tag_limit = 3000
```

Related: DEVOPS-174