### PR TITLE
Change: excluded ADD_PREFERENCE pattern from duplcated script check

### DIFF
--- a/tests/plugins/test_duplicated_script_tags.py
+++ b/tests/plugins/test_duplicated_script_tags.py
@@ -82,3 +82,18 @@ class CheckDuplicatedScriptTagsTestCase(PluginTestCase):
             "'cvss_base' multiple number of times.",
             results[0].message,
         )
+
+    def test_excluded_tag(self):
+        path = Path("some/file.nasl")
+        content = (
+            'script_add_preference(name:"Test", type:"checkbox");\n'
+            'script_add_preference(name:"Test2", type:"checkbox");\n'
+        )
+
+        results = list(
+            CheckDuplicatedScriptTags.run(
+                path,
+                content,
+            )
+        )
+        self.assertEqual(len(results), 0)

--- a/troubadix/plugins/duplicated_script_tags.py
+++ b/troubadix/plugins/duplicated_script_tags.py
@@ -33,10 +33,15 @@ class CheckDuplicatedScriptTags(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
+
         special_script_tag_patterns = get_special_script_tag_patterns()
         for tag, pattern in special_script_tag_patterns.items():
             # TBD: script_name might also look like this:
             # script_name("MyVT (Windows)");
+
+            if tag.name == "ADD_PREFERENCE":
+                continue
+
             match = pattern.finditer(file_content)
 
             if match:


### PR DESCRIPTION
**What**:

Exclude tag  script_add_preference from plugin CheckDuplicatedScriptTags.

**Why**:

Tag is actually allowed to occur multiple times.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
