### PR TITLE
Workaround vt root

### DIFF
--- a/tests/plugins/test_dependencies.py
+++ b/tests/plugins/test_dependencies.py
@@ -28,7 +28,7 @@ here = Path.cwd()
 
 class CheckDoubleEndPointsTestCase(PluginTestCase):
     def setUp(self) -> None:
-        self.dir = here / _ROOT / "foo"
+        self.dir = here / _ROOT / "22.04"
         self.dir.mkdir(parents=True)
         self.dep = self.dir / "example.inc"
         self.dep.touch()

--- a/tests/plugins/test_dependency_category_order.py
+++ b/tests/plugins/test_dependency_category_order.py
@@ -30,7 +30,7 @@ here = Path.cwd()
 
 class CheckDependencyCategoryOrderTestCase(PluginTestCase):
     def setUp(self) -> None:
-        self.dir = here / _ROOT / "foo"
+        self.dir = here / _ROOT / "22.04"
         self.dir.mkdir(parents=True)
         self.dep = self.dir / "example.inc"
         self.dep.write_text("script_category(ACT_ATTACK);")

--- a/tests/plugins/test_deprecated_dependency.py
+++ b/tests/plugins/test_deprecated_dependency.py
@@ -28,7 +28,7 @@ here = Path.cwd()
 
 class CheckDeprecatedDependencyTestCase(PluginTestCase):
     def setUp(self) -> None:
-        self.dir = here / _ROOT / "foo"
+        self.dir = here / _ROOT / "22.04"
         self.dir.mkdir(parents=True)
         self.dep = self.dir / "example.inc"
         self.dep.write_text("script_category(ACT_ATTACK);\n exit(66);")

--- a/tests/plugins/test_vt_placement.py
+++ b/tests/plugins/test_vt_placement.py
@@ -28,7 +28,7 @@ here = Path.cwd()
 
 class CheckVTPlacementTestCase(PluginTestCase):
     def setUp(self) -> None:
-        self.dir = here / _ROOT / "foo"
+        self.dir = here / _ROOT / "22.04"
         self.dir.mkdir(parents=True)
 
         return super().setUp()

--- a/troubadix/helper/helper.py
+++ b/troubadix/helper/helper.py
@@ -96,12 +96,21 @@ class Root:
     instance = False
 
     def __init__(self, path: Path, root: str = _ROOT) -> None:
+        file_path = str(path.resolve())
         match = re.search(
-            rf"(?P<path>/([\w\-\.\\ ]+/)+{root}/[\w\-\.]+/)",
-            str(path.resolve()),
+            rf"(?P<path>/([\w\-\.\\ ]+/)+{root}/)",
+            file_path,
         )
         if match:
-            self.root = Path(match.group("path"))
+            match_path = Path(match.group("path"))
+            if f'{root}/common' in file_path:
+                self.root = match_path / 'common'
+            elif f'{root}/21.04' in file_path:
+                self.root = match_path / '21.04'
+            elif f'{root}/22.04' in file_path:
+                self.root = match_path / '22.04'
+            else:
+                self.root = match_path
             if not self.root.exists():
                 self.root = None
         else:

--- a/troubadix/helper/helper.py
+++ b/troubadix/helper/helper.py
@@ -103,12 +103,12 @@ class Root:
         )
         if match:
             match_path = Path(match.group("path"))
-            if f'{root}/common' in file_path:
-                self.root = match_path / 'common'
-            elif f'{root}/21.04' in file_path:
-                self.root = match_path / '21.04'
-            elif f'{root}/22.04' in file_path:
-                self.root = match_path / '22.04'
+            if f"{root}/common" in file_path:
+                self.root = match_path / "common"
+            elif f"{root}/21.04" in file_path:
+                self.root = match_path / "21.04"
+            elif f"{root}/22.04" in file_path:
+                self.root = match_path / "22.04"
             else:
                 self.root = match_path
             if not self.root.exists():


### PR DESCRIPTION
**What**: Simple workaround for vt root if its name is nasl
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
DEVOPS-190
If the root nasl directory is named nasl and not, for example nasl/common, symlinks will be resolved incorrectly.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
