### PR TITLE
Fix: Ensure parsing arguments for troubadix

### DIFF
--- a/troubadix/argparser.py
+++ b/troubadix/argparser.py
@@ -214,6 +214,7 @@ def parse_args(
     )
 
     if not args:
+        print("No arguments given.", file=sys.stderr)
         parser.print_help(sys.stdout)
         sys.exit(1)
 

--- a/troubadix/troubadix.py
+++ b/troubadix/troubadix.py
@@ -109,6 +109,9 @@ def main(args=None):
     term = Terminal()
     _set_terminal(term)
 
+    if not args:
+        args = sys.argv[1:]
+
     parsed_args = parse_args(args=args)
 
     # Full will run in the root directory of executing. (Like pwd)
@@ -119,6 +122,7 @@ def main(args=None):
     else:
         dirs = parsed_args.dirs
 
+    files = None
     if dirs:
         include_patterns, exclude_patterns = generate_patterns(
             include_patterns=parsed_args.include_patterns,


### PR DESCRIPTION
**What**:

Always pass arguments to the parse_args function.

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
