### PR TITLE
Add: New exclusions for `http_links_in_tags`

### DIFF
--- a/tests/plugins/test_http_links_in_tags.py
+++ b/tests/plugins/test_http_links_in_tags.py
@@ -131,6 +131,11 @@ class CheckHttpLinksInTagsTestCase(PluginTestCase):
             "29. https://www.phishingtarget.com@evil.com",
             "30. 'http://'",
             "31. 'https://'",
+            "32. distributions on ftp.proftpd.org have all been",
+            "33. information from www.mutt.org:",
+            "34. According to www.tcpdump.org:",
+            "35. According to www.kde.org:",
+            "36. From the www.info-zip.org site:",
         ]
 
         for testcase in testcases:

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -147,6 +147,11 @@ class CheckHttpLinksInTags(FilePlugin):
             "wget https://compromised-domain.com/important-file",
             "the https:// scheme",
             "https://www.phishingtarget.com@evil.com",
+            "distributions on ftp.proftpd.org have all been",
+            "information from www.mutt.org:",
+            "According to www.tcpdump.org:",
+            "According to www.kde.org:",
+            "From the www.info-zip.org site:",
             # e.g.:
             # Since gedit supports opening files via 'http://' URLs
             "'http://'",


### PR DESCRIPTION
**What**:

Added recent exclusions to the exclusion list

**Why**:

To keep parity between the old QA and troubadix.

MR 11193 in VTS repo

**How**:

Added new testcases and confirmed they ran successfully

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
