### PR TITLE
Change: Cleanup linter reporting classes

### DIFF
--- a/tests/plugins/test_duplicated_oid.py
+++ b/tests/plugins/test_duplicated_oid.py
@@ -18,7 +18,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from troubadix.plugin import LinterError, LinterMessage
+from troubadix.plugin import LinterError
 from troubadix.plugins.duplicate_oid import CheckDuplicateOID
 
 from . import PluginTestCase
@@ -54,7 +54,7 @@ class CheckDuplicateOIDTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 1)
-        self.assertIsInstance(results[0], LinterMessage)
+        self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             "test_files/nasl/21.04/fail_badwords.nasl: Could not find an OID.",
             results[0].message,

--- a/tests/plugins/test_no_solution.py
+++ b/tests/plugins/test_no_solution.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from troubadix.plugin import LinterMessage
+from troubadix.plugin import LinterWarning
 from troubadix.plugins.no_solution import CheckNoSolution
 
 from . import PluginTestCase
@@ -47,7 +47,7 @@ class CheckNoSolutionTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 5)
-        self.assertIsInstance(results[0], LinterMessage)
+        self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
             "test_files/nasl/21.04/fail_solution_template.nasl:"
             " Missing solution, older than 1 year.",
@@ -73,7 +73,7 @@ class CheckNoSolutionTestCase(PluginTestCase):
         file1.write_text(text, encoding="latin-1")
 
         self.assertEqual(len(results), 5)
-        self.assertIsInstance(results[0], LinterMessage)
+        self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
             "test_files/nasl/21.04/fail_solution_template.nasl:"
             " Missing solution, older than 6 months.",
@@ -99,7 +99,7 @@ class CheckNoSolutionTestCase(PluginTestCase):
         file1.write_text(text, encoding="latin-1")
 
         self.assertEqual(len(results), 5)
-        self.assertIsInstance(results[0], LinterMessage)
+        self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
             "test_files/nasl/21.04/fail_solution_template.nasl:"
             " Missing solution, but younger than 31 days.",

--- a/troubadix/plugin.py
+++ b/troubadix/plugin.py
@@ -24,12 +24,10 @@ from troubadix.helper import CURRENT_ENCODING
 
 
 @dataclass
-class LinterMessage:
-    message: str
-
-
-class LinterResult(LinterMessage):
+class LinterResult:
     """A result found during running a check"""
+
+    message: str
 
 
 class LinterWarning(LinterResult):

--- a/troubadix/runner.py
+++ b/troubadix/runner.py
@@ -34,7 +34,6 @@ from troubadix.plugin import (
     FilesPluginContext,
     LinterError,
     LinterFix,
-    LinterMessage,
     LinterResult,
     LinterWarning,
     FilePluginContext,
@@ -153,7 +152,7 @@ class Runner:
             with self._log_file.open(mode="a", encoding="utf-8") as f:
                 f.write(f"{message}\n")
 
-    def _report_results(self, results: Iterable[LinterMessage]) -> None:
+    def _report_results(self, results: Iterable[LinterResult]) -> None:
         for result in results:
             if isinstance(result, (LinterResult, LinterFix)):
                 self._report_ok(result.message)


### PR DESCRIPTION
**What**:

Drop the LinterMessage and change LinterResult into the base class.

**Why**:

LinterMessage was more or less unused and therefore unnecessary.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
