### PR TITLE
New and fixed entries to codespell.exclude

### DIFF
--- a/troubadix/codespell/codespell.exclude
+++ b/troubadix/codespell/codespell.exclude
@@ -624,14 +624,14 @@ reenable php7-dba support of Berkeley DB (bsc#1108554)");
     reg_xml = '\t\t<registry_item' + status + ' xmlns="http://oval.mitre.org/' +
 ** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none.(CVE-2020-16598)
 Reject invalid eliptic curve point coordinates (bsc#1131291)");
-rejection for EXTRAVERSION = -xfs, but likely little else will be
+ rejection for EXTRAVERSION = -xfs, but likely little else will be
   - Remote Command Execution via WAN and LAN
   - Remote Unauthenticated Information Disclosure via WAN and LAN
 	Remove all mitre.org links from the script descriptions as
 	Removed script_xref references to cve.mitre.org. This
 	Remove reference to cve.mitre.org from insight tag.
 report_dead = script_get_preference( "Report about unrechable Hosts", id:6 );
-Reported by Aurelien Delaitre (SATE 2009).
+ Reported by Aurelien Delaitre (SATE 2009).
   reporter of CVE-2010-0542 Adrian 'pagvac' Pastor of GNUCITIZEN and Tim
   reporter of CVE-2010-0542, Adrian 'pagvac' Pastor of GNUCITIZEN and Tim
     report = "Keiner der unter Punkt 2.2.1.2 geforderten Ciphers wurde auf dem System unter Port " + port + " gefunden.";
@@ -984,6 +984,7 @@ The GOST ENGINE in OpenSSL before 1.0.0f does not properly handle
   the only recommendations are to deny any access to ports 10000 and 10001 from WAN (if port-forwarding is enabled to allow remote
 The previous update of tcpdump already fixed variuous Buffer overflow/overread vulnerabilities [bsc#1153098, bsc#1153332]
 the router to stop forwarding data traffic across Traffic Engineering (TE) tunnels, resulting in a denial of
+The rust regex crate did not properly prevent crafted regular expressions from taking an arbitrary amount of time during parsing. If an attacker was able to supply input to this crate, they could have caused a denial of service in the browser.
   The sbni_ioctl function in drivers/net/wan/sbni.c in the wan
   The SER product has been found to contain a vulnerability where ACKs
 Theses non-security issues were fixed:


### PR DESCRIPTION
**What**:

Recent additions and fixes to codespell.exclude

**Why**:

To keep parity between old QA and troubadix


- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
