### PR TITLE
Extend linter results

### DIFF
--- a/tests/plugins/test_copyright_year.py
+++ b/tests/plugins/test_copyright_year.py
@@ -36,7 +36,6 @@ class CheckCopyrightYearTestCase(PluginTestCase):
         plugin = CheckCopyrightYear(fake_context)
 
         results = list(plugin.run())
-        print(results)
         self.assertEqual(len(results), 0)
 
     def test_missing_creation_date(self):

--- a/tests/plugins/test_duplicated_oid.py
+++ b/tests/plugins/test_duplicated_oid.py
@@ -56,7 +56,7 @@ class CheckDuplicateOIDTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "test_files/nasl/21.04/fail_badwords.nasl: Could not find an OID.",
+            "Could not find an OID.",
             results[0].message,
         )
 
@@ -73,8 +73,8 @@ class CheckDuplicateOIDTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "test_files/nasl/21.04/test.nasl: OID 1.3.6.1.4.1.25623.1.0.100312"
-            " already used by 'test_files/nasl/21.04/fail.nasl'",
+            "OID 1.3.6.1.4.1.25623.1.0.100312 already used by "
+            "'test_files/nasl/21.04/fail.nasl'",
             results[0].message,
         )
 
@@ -96,7 +96,6 @@ class CheckDuplicateOIDTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "test_files/nasl/21.04/fail_name_and_copyright_newline.nasl: "
             "Invalid OID 1.2.3.4.5.6.78909.8.7.654321 found.",
             results[0].message,
         )

--- a/tests/plugins/test_encoding.py
+++ b/tests/plugins/test_encoding.py
@@ -65,14 +65,14 @@ class CheckEncodingTestCase(PluginTestCase):
 
             self.assertIsInstance(results[0], LinterError)
             self.assertEqual(
-                f"VT '{path}' has a wrong encoding.",
+                "VT uses a wrong encoding. Detected encoding is utf-8.",
                 results[0].message,
             )
             self.assertEqual(
-                "Found invalid character in line 0",
+                "Found invalid character",
                 results[1].message,
             )
             self.assertEqual(
-                "Found invalid character in line 1",
+                "Found invalid character",
                 results[2].message,
             )

--- a/tests/plugins/test_no_solution.py
+++ b/tests/plugins/test_no_solution.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from troubadix.helper import CURRENT_ENCODING
 from troubadix.plugin import LinterWarning
 from troubadix.plugins.no_solution import CheckNoSolution
 
@@ -29,7 +30,7 @@ here = Path(__file__).parent
 
 class CheckNoSolutionTestCase(PluginTestCase):
     def test_ok(self):
-        file1 = here / "test_files/nasl/21.04/test.nasl"
+        file1 = here / "test_files" / "nasl" / "21.04" / "test.nasl"
         context = MagicMock()
         context.nasl_files = [file1]
         context.root = here
@@ -39,7 +40,13 @@ class CheckNoSolutionTestCase(PluginTestCase):
         self.assertEqual(len(results), 0)
 
     def test_too_old_1_year(self):
-        file1 = here / "test_files/nasl/21.04/fail_solution_template.nasl"
+        file1 = (
+            here
+            / "test_files"
+            / "nasl"
+            / "21.04"
+            / "fail_solution_template.nasl"
+        )
         context = MagicMock()
         context.nasl_files = [file1]
         context.root = here
@@ -49,18 +56,24 @@ class CheckNoSolutionTestCase(PluginTestCase):
         self.assertEqual(len(results), 5)
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "test_files/nasl/21.04/fail_solution_template.nasl:"
-            " Missing solution, older than 1 year.",
+            "Missing solution, older than 1 year.",
             results[0].message,
         )
 
     def test_too_old_6_months(self):
-        file1 = here / "test_files/nasl/21.04/fail_solution_template.nasl"
+        file1 = (
+            here
+            / "test_files"
+            / "nasl"
+            / "21.04"
+            / "fail_solution_template.nasl"
+        )
         new_date = (datetime.now() - timedelta(days=200)).strftime("%Y/%m/%d")
 
-        text = file1.read_text(encoding="latin-1")
+        text = file1.read_text(encoding=CURRENT_ENCODING)
         file1.write_text(
-            text.replace("02nd February, 2021", new_date), encoding="latin-1"
+            text.replace("02nd February, 2021", new_date),
+            encoding=CURRENT_ENCODING,
         )
 
         context = MagicMock()
@@ -70,23 +83,29 @@ class CheckNoSolutionTestCase(PluginTestCase):
         results = list(plugin.run())
 
         # reverse change to file
-        file1.write_text(text, encoding="latin-1")
+        file1.write_text(text, encoding=CURRENT_ENCODING)
 
         self.assertEqual(len(results), 5)
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "test_files/nasl/21.04/fail_solution_template.nasl:"
-            " Missing solution, older than 6 months.",
+            "Missing solution, older than 6 months.",
             results[0].message,
         )
 
     def test_too_young_31_days(self):
-        file1 = here / "test_files/nasl/21.04/fail_solution_template.nasl"
+        file1 = (
+            here
+            / "test_files"
+            / "nasl"
+            / "21.04"
+            / "fail_solution_template.nasl"
+        )
         new_date = (datetime.now() - timedelta(days=10)).strftime("%Y/%m/%d")
 
-        text = file1.read_text(encoding="latin-1")
+        text = file1.read_text(encoding=CURRENT_ENCODING)
         file1.write_text(
-            text.replace("02nd February, 2021", new_date), encoding="latin-1"
+            text.replace("02nd February, 2021", new_date),
+            encoding=CURRENT_ENCODING,
         )
 
         context = MagicMock()
@@ -96,35 +115,55 @@ class CheckNoSolutionTestCase(PluginTestCase):
         results = list(plugin.run())
 
         # reverse change to file
-        file1.write_text(text, encoding="latin-1")
+        file1.write_text(text, encoding=CURRENT_ENCODING)
 
         self.assertEqual(len(results), 5)
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "test_files/nasl/21.04/fail_solution_template.nasl:"
-            " Missing solution, but younger than 31 days.",
+            "Missing solution, but younger than 31 days.",
             results[0].message,
         )
 
     def test_multiples(self):
-        file1 = here / "test_files/nasl/21.04/fail_solution_template.nasl"
-        file2 = here / "test_files/nasl/21.04/fail_solution_template2.nasl"
-        file3 = here / "test_files/nasl/21.04/fail_solution_template3.nasl"
+        file1 = (
+            here
+            / "test_files"
+            / "nasl"
+            / "21.04"
+            / "fail_solution_template.nasl"
+        )
+        file2 = (
+            here
+            / "test_files"
+            / "nasl"
+            / "21.04"
+            / "fail_solution_template2.nasl"
+        )
+        file3 = (
+            here
+            / "test_files"
+            / "nasl"
+            / "21.04"
+            / "fail_solution_template3.nasl"
+        )
 
         date1 = (datetime.now() - timedelta(days=200)).strftime("%Y/%m/%d")
         date2 = (datetime.now() - timedelta(days=400)).strftime("%Y/%m/%d")
         date3 = (datetime.now() - timedelta(days=10)).strftime("%Y/%m/%d")
 
-        text = file1.read_text(encoding="latin-1")
+        text = file1.read_text(encoding=CURRENT_ENCODING)
 
         file1.write_text(
-            text.replace("02nd February, 2021", date1), encoding="latin-1"
+            text.replace("02nd February, 2021", date1),
+            encoding=CURRENT_ENCODING,
         )
         file2.write_text(
-            text.replace("02nd February, 2021", date2), encoding="latin-1"
+            text.replace("02nd February, 2021", date2),
+            encoding=CURRENT_ENCODING,
         )
         file3.write_text(
-            text.replace("02nd February, 2021", date3), encoding="latin-1"
+            text.replace("02nd February, 2021", date3),
+            encoding=CURRENT_ENCODING,
         )
 
         context = MagicMock()
@@ -134,7 +173,7 @@ class CheckNoSolutionTestCase(PluginTestCase):
         results = list(plugin.run())
 
         # reverse change to file
-        file1.write_text(text, encoding="latin-1")
+        file1.write_text(text, encoding=CURRENT_ENCODING)
         file2.unlink()
         file3.unlink()
 

--- a/tests/plugins/test_script_version_and_last_modification_tags.py
+++ b/tests/plugins/test_script_version_and_last_modification_tags.py
@@ -63,12 +63,11 @@ class CheckScriptVersionAndLastModificationTagsTestCase(PluginTestCase):
         self.assertEqual(len(results), 2)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            f"VT '{str(nasl_file)}' is missing script_version(); or is using "
-            "a wrong syntax.\n",
+            "VT is missing script_version(); or is using a wrong syntax.",
             results[0].message,
         )
         self.assertEqual(
-            f"VT '{str(nasl_file)}' is missing script_tag("
-            'name:"last_modification" or is using a wrong syntax.\n',
+            "VT is missing script_tag("
+            'name:"last_modification" or is using a wrong syntax.',
             results[1].message,
         )

--- a/tests/plugins/test_solution_type.py
+++ b/tests/plugins/test_solution_type.py
@@ -65,7 +65,7 @@ class CheckSolutionTypeTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT some/file.nasl does not contain a solution_type",
+            "VT does not contain a solution_type",
             results[0].message,
         )
 
@@ -86,6 +86,6 @@ class CheckSolutionTypeTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT some/file.nasl does not contain a valid solution_type 'value'",
+            "VT does not contain a valid solution_type 'value'",
             results[0].message,
         )

--- a/tests/plugins/test_tabs.py
+++ b/tests/plugins/test_tabs.py
@@ -51,6 +51,7 @@ class CheckTabsTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "Found tabs in line 1.",
             results[0].message,
+            "VT uses tabs instead of spaces.",
         )
+        self.assertEqual(results[0].line, 1)

--- a/tests/plugins/test_todo_tbd.py
+++ b/tests/plugins/test_todo_tbd.py
@@ -76,14 +76,22 @@ class CheckTodoTbdTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[0].message,
+        )
+        self.assertEqual(
+            results[0].line,
+            1,
         )
 
         self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[1].message,
+        )
+        self.assertEqual(
+            results[1].line,
+            2,
         )
 
     def test_todo(self):
@@ -105,15 +113,17 @@ class CheckTodoTbdTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[0].message,
         )
+        self.assertEqual(results[0].line, 1)
 
         self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[1].message,
         )
+        self.assertEqual(results[1].line, 2)
 
     def test_at_todo(self):
         path = Path("some/file.nasl")
@@ -134,15 +144,17 @@ class CheckTodoTbdTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[0].message,
         )
+        self.assertEqual(results[0].line, 1)
 
         self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[1].message,
         )
+        self.assertEqual(results[1].line, 2)
 
     def test_mixed(self):
         path = Path("some/file.nasl")
@@ -163,18 +175,21 @@ class CheckTodoTbdTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 1",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[0].message,
         )
+        self.assertEqual(results[0].line, 1)
 
         self.assertIsInstance(results[1], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 2",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[1].message,
         )
+        self.assertEqual(results[1].line, 2)
 
         self.assertIsInstance(results[2], LinterWarning)
         self.assertEqual(
-            "VT some/file.nasl contains #TODO/TBD/@todo keywords at line 4",
+            "VT contains #TODO/TBD/@todo keywords.",
             results[2].message,
         )
+        self.assertEqual(results[2].line, 4)

--- a/tests/plugins/test_update_modification_date.py
+++ b/tests/plugins/test_update_modification_date.py
@@ -59,13 +59,11 @@ class TestUpdateModificationDate(PluginTestCase):
 
         output = plugin.run()
 
-        expected_error = LinterError(
-            "VT does not contain a modification day script tag."
-        )
-
         error = next(output)
         self.assertIsInstance(error, LinterError)
-        self.assertEqual(error, expected_error)
+        self.assertEqual(
+            error.message, "VT does not contain a modification day script tag."
+        )
 
         new_content = nasl_file.read_text(encoding=CURRENT_ENCODING)
         self.assertEqual(content, new_content)
@@ -81,12 +79,10 @@ class TestUpdateModificationDate(PluginTestCase):
         plugin = UpdateModificationDate(fake_context)
 
         output = plugin.run()
-
-        expected_error = LinterError("VT does not contain a script version.")
-
         error = next(output)
+
         self.assertIsInstance(error, LinterError)
-        self.assertEqual(error, expected_error)
+        self.assertEqual(error.message, "VT does not contain a script version.")
 
         new_content = nasl_file.read_text(encoding=CURRENT_ENCODING)
         self.assertEqual(content, new_content)

--- a/tests/plugins/test_using_display.py
+++ b/tests/plugins/test_using_display.py
@@ -58,8 +58,7 @@ class CheckUsingDisplayTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT/Include 'some/file.nasl' is using a display() "
-            'function at: display("FOO");',
+            'VT/Include is using a display() function at: display("FOO");',
             results[0].message,
         )
 
@@ -81,7 +80,7 @@ class CheckUsingDisplayTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "VT 'some/file.nasl' is using a display() function which is "
+            "VT is using a display() function which is "
             "protected by a comment or an if statement at: "
             'if (0) display("FOO");.',
             results[0].message,
@@ -105,7 +104,7 @@ class CheckUsingDisplayTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterWarning)
         self.assertEqual(
-            "VT 'some/file.nasl' is using a display() function which is "
+            "VT is using a display() function which is "
             "protected by a comment or an if statement at: "
             '# display("FOO");.',
             results[0].message,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,16 +18,13 @@
 
 import io
 import unittest
-
 from contextlib import redirect_stdout
 from pathlib import Path
 
 from pontos.terminal import _set_terminal
 from pontos.terminal.terminal import Terminal
-
 from troubadix.helper import CURRENT_ENCODING
 from troubadix.helper.helper import get_path_from_root
-
 from troubadix.plugins import _PLUGINS
 from troubadix.plugins.badwords import CheckBadwords
 from troubadix.plugins.copyright_text import CheckCopyrightText
@@ -395,7 +392,7 @@ class TestRunner(unittest.TestCase):
 
     def test_runner_log_file(self):
         included_plugins = [
-            "CheckMissingDescExit",
+            CheckMissingDescExit.name,
         ]
         nasl_file = (
             _here
@@ -423,12 +420,11 @@ class TestRunner(unittest.TestCase):
 
         compare_content = (
             "\tPre-Run Plugins: check_duplicate_oid, check_no_solution\n"
-            "\tIncluded Plugins: CheckMissingDescExit\n"
+            "\tIncluded Plugins: check_missing_desc_exit\n"
             "\tRunning plugins: check_missing_desc_exit\n"
             "\n\nRun plugin check_duplicate_oid\n"
             "\tResults for plugin check_duplicate_oid\n"
-            f"\t\t{get_path_from_root(nasl_file, self.root)}: Invalid OID "
-            "1.2.3.4.5.6.78909.1.7.654321 found.\n\n\n"
+            "\t\tInvalid OID 1.2.3.4.5.6.78909.1.7.654321 found.\n\n\n"
             "Run plugin check_no_solution\n"
             "\t\tNo results for plugin check_no_solution\n\n\n"
             f"Checking {get_path_from_root(nasl_file, self.root)} (1/1)\n\t\t"

--- a/troubadix/plugin.py
+++ b/troubadix/plugin.py
@@ -18,7 +18,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, Optional
 
 from troubadix.helper import CURRENT_ENCODING
 
@@ -28,6 +28,9 @@ class LinterResult:
     """A result found during running a check"""
 
     message: str
+    file: Optional[Path] = None
+    plugin: Optional[str] = None
+    line: Optional[int] = None
 
 
 class LinterWarning(LinterResult):

--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -100,7 +100,7 @@ class CheckBadwords(LineContentPlugin):
         if is_ignore_file(nasl_file, _IGNORE_FILES):
             return
 
-        for i, line in enumerate(lines):
+        for i, line in enumerate(lines, 1):
             if any(badword in line for badword in DEFAULT_BADWORDS):
                 if (
                     not any(exception in line for exception in EXCEPTIONS)

--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -113,4 +113,9 @@ class CheckBadwords(LineContentPlugin):
                         for filename, value in COMBINED
                     )
                 ):
-                    yield LinterError(f"Badword in line {i+1:5}: {line}")
+                    yield LinterError(
+                        f"Badword in line {i:5}: {line}",
+                        plugin=self.name,
+                        file=nasl_file,
+                        line=i,
+                    )

--- a/troubadix/plugins/copyright_text.py
+++ b/troubadix/plugins/copyright_text.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+
 from pathlib import Path
 from typing import Iterator
 
@@ -86,7 +87,9 @@ class CheckCopyrightText(FileContentPlugin):
                 "The VT is using an incorrect syntax for its copyright "
                 "statement. Please start (EXACTLY) with:\n"
                 "'script_copyright(\"Copyright (C) followed by the year "
-                "(matching the one in creation_date) and the author/company."
+                "(matching the one in creation_date) and the author/company.",
+                file=nasl_file,
+                plugin=self.name,
             )
 
         match = re.search(
@@ -105,7 +108,9 @@ class CheckCopyrightText(FileContentPlugin):
             )
 
             yield LinterError(
-                "The VT was using an incorrect copyright statement."
+                "The VT was using an incorrect copyright statement.",
+                file=nasl_file,
+                plugin=self.name,
             )
 
     def fix(self) -> Iterator[LinterResult]:
@@ -118,5 +123,7 @@ class CheckCopyrightText(FileContentPlugin):
         )
 
         yield LinterFix(
-            f"The copyright has been updated to {CORRECT_COPYRIGHT_PHRASE}"
+            f"The copyright has been updated to {CORRECT_COPYRIGHT_PHRASE}",
+            file=nasl_file,
+            plugin=self.name,
         )

--- a/troubadix/plugins/copyright_year.py
+++ b/troubadix/plugins/copyright_year.py
@@ -72,7 +72,11 @@ class CheckCopyrightYear(LineContentPlugin):
                 copyrights.append((i, line, copyright_match.group(2)))
 
         if not creation_year:
-            yield LinterError("Missing creation_date statement in VT")
+            yield LinterError(
+                "Missing creation_date statement in VT",
+                file=nasl_file,
+                plugin=self.name,
+            )
 
         # key is the line where the copyright is found, value the year found
         # within that line
@@ -80,5 +84,8 @@ class CheckCopyrightYear(LineContentPlugin):
             if copyright_year != creation_year:
                 yield LinterError(
                     "VT contains a Copyright year not matching "
-                    f"the year {creation_year} at line {nr}"
+                    f"the year {creation_year} at line {nr}",
+                    file=nasl_file,
+                    plugin=self.name,
+                    line=nr,
                 )

--- a/troubadix/plugins/creation_date.py
+++ b/troubadix/plugins/creation_date.py
@@ -40,7 +40,11 @@ class CheckCreationDate(FileContentPlugin):
             return
 
         if not "creation_date" in file_content:
-            yield LinterError("No creation date has been found.")
+            yield LinterError(
+                "No creation date has been found.",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         tag_pattern = get_script_tag_pattern(ScriptTag.CREATION_DATE)
@@ -60,7 +64,9 @@ class CheckCreationDate(FileContentPlugin):
                 week_day_parsed = date_right.strftime("%a")
             except ValueError:
                 yield LinterError(
-                    "False or incorrectly formatted creation_date."
+                    "False or incorrectly formatted creation_date.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
                 return
 
@@ -68,15 +74,23 @@ class CheckCreationDate(FileContentPlugin):
             # Wed, 29 Nov 2017
             if date_left.date() != date_right.date():
                 yield LinterError(
-                    "The creation_date consists of two different dates."
+                    "The creation_date consists of two different dates.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
             # Check correct weekday
             elif week_day_str != week_day_parsed:
                 formatted_date = week_day_parsed
                 yield LinterError(
                     f"Wrong day of week. Please change it from '{week_day_str}"
-                    f"' to '{formatted_date}'."
+                    f"' to '{formatted_date}'.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
         else:
-            yield LinterError("False or incorrectly formatted creation_date.")
+            yield LinterError(
+                "False or incorrectly formatted creation_date.",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return

--- a/troubadix/plugins/cve_format.py
+++ b/troubadix/plugins/cve_format.py
@@ -56,7 +56,11 @@ class CheckCVEFormat(FileContentPlugin):
         # ("CVE-2017-2750");
         match_result = re.search("(?<=script_cve_id)[^;]+", file_content)
         if match_result is None or match_result.group(0) is None:
-            yield LinterWarning("VT does not refer to any CVEs.")
+            yield LinterWarning(
+                "VT does not refer to any CVEs.",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         found_cves = []
@@ -65,7 +69,11 @@ class CheckCVEFormat(FileContentPlugin):
         for match in matches:
             result = re.search(r'"CVE-\d{4}-\d{4,7}"', match)
             if result is None or result.group(0) is None:
-                yield LinterError("VT uses an invalid CVE format.")
+                yield LinterError(
+                    "VT uses an invalid CVE format.",
+                    file=nasl_file,
+                    plugin=self.name,
+                )
                 return
 
             cve = result.group(0)
@@ -73,14 +81,24 @@ class CheckCVEFormat(FileContentPlugin):
             if len(cve) > 15 and cve[10] == "0":
                 yield LinterError(
                     "The last group of CVE digits of the VT "
-                    "must not start with a 0 if there are more than 4 digits."
+                    "must not start with a 0 if there are more than 4 digits.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
 
             year = cve.split("-")
             if not 1999 <= int(year[1]) <= current_year:
-                yield LinterError("VT uses an invalid year in CVE format.")
+                yield LinterError(
+                    "VT uses an invalid year in CVE format.",
+                    file=nasl_file,
+                    plugin=self.name,
+                )
 
             if cve in found_cves:
-                yield LinterError(f"VT is using CVE {cve} multiple times.")
+                yield LinterError(
+                    f"VT is using CVE {cve} multiple times.",
+                    file=nasl_file,
+                    plugin=self.name,
+                )
 
             found_cves.append(cve)

--- a/troubadix/plugins/cvss_format.py
+++ b/troubadix/plugins/cvss_format.py
@@ -40,15 +40,25 @@ class CheckCVSSFormat(FileContentPlugin):
 
         missing_cvss_base = re.search('"cvss_base", value:""', file_content)
         if missing_cvss_base:
-            yield LinterError("VT has a missing cvss_base value.")
+            yield LinterError(
+                "VT has a missing cvss_base value.",
+                file=nasl_file,
+                plugin=self.name,
+            )
         else:
             cvss_detect = cvss_base_pattern.search(file_content)
             if not cvss_detect:
-                yield LinterError("VT has an invalid cvss_base value.")
+                yield LinterError(
+                    "VT has an invalid cvss_base value.",
+                    file=nasl_file,
+                    plugin=self.name,
+                )
 
         vector_match = cvss_base_vector_pattern.search(file_content)
 
         if not vector_match:
             yield LinterError(
-                "VT has a missing or invalid cvss_base_vector value."
+                "VT has a missing or invalid cvss_base_vector value.",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/dependencies.py
+++ b/troubadix/plugins/dependencies.py
@@ -65,7 +65,9 @@ class CheckDependencies(FilePlugin):
                     if not (root / dep).exists():
                         yield LinterError(
                             f"The script dependency {dep} could not "
-                            "be found within the VTs."
+                            "be found within the VTs.",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )
                         continue
 
@@ -93,10 +95,14 @@ class CheckDependencies(FilePlugin):
                     if parent_folder in ["PCIDSS", "Policy", "GSHB"]:
                         yield LinterWarning(
                             f"The script dependency {dep} is in a "
-                            "subdirectory, which might be misplaced."
+                            "subdirectory, which might be misplaced.",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )
                     else:
                         yield LinterError(
                             f"The script dependency {dep} is within "
-                            "a subdirectory, which is not allowed."
+                            "a subdirectory, which is not allowed.",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )

--- a/troubadix/plugins/dependency_category_order.py
+++ b/troubadix/plugins/dependency_category_order.py
@@ -105,7 +105,11 @@ class CheckDependencyCategoryOrder(FileContentPlugin):
                 script=nasl_file.name,
             )
         except CategoryError as e:
-            yield LinterError(str(e))
+            yield LinterError(
+                str(e),
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         dependencies_pattern = get_special_script_tag_pattern(
@@ -131,7 +135,9 @@ class CheckDependencyCategoryOrder(FileContentPlugin):
                     if not dependency_path.exists():
                         yield LinterError(
                             f"The script dependency {dep} could not "
-                            "be found within the VTs."
+                            "be found within the VTs.",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                     else:
                         # TODO: gsf/PCIDSS/PCI-DSS.nasl,
@@ -152,7 +158,11 @@ class CheckDependencyCategoryOrder(FileContentPlugin):
                                 script=dependency_path.name,
                             )
                         except CategoryError as e:
-                            yield LinterError(str(e))
+                            yield LinterError(
+                                str(e),
+                                file=nasl_file,
+                                plugin=self.name,
+                            )
 
                         if category.value < dependency_category.value:
                             yield LinterError(
@@ -160,7 +170,9 @@ class CheckDependencyCategoryOrder(FileContentPlugin):
                                 f"({category.value}) is lower than "
                                 f"the category {dependency_category.name}"
                                 f"({dependency_category.value}) of the "
-                                f"dependency {dep}."
+                                f"dependency {dep}.",
+                                file=nasl_file,
+                                plugin=self.name,
                             )
                         # nb: Currently not sure about the
                         # host_alive_detection.nasl dependency so
@@ -174,5 +186,7 @@ class CheckDependencyCategoryOrder(FileContentPlugin):
                                 f"category {dependency_category.name}"
                                 f"({dependency_category.value}), but no VT"
                                 " is allowed to have a direct dependency "
-                                "to VTs in this category."
+                                "to VTs in this category.",
+                                file=nasl_file,
+                                plugin=self.name,
                             )

--- a/troubadix/plugins/deprecated_dependency.py
+++ b/troubadix/plugins/deprecated_dependency.py
@@ -73,7 +73,9 @@ class CheckDeprecatedDependency(FilePlugin):
                     if not dependency_path.exists():
                         yield LinterError(
                             f"The script dependency {dep} could not "
-                            "be found within the VTs."
+                            "be found within the VTs.",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )
                     else:
                         # TODO: gsf/PCIDSS/PCI-DSS.nasl,
@@ -93,5 +95,7 @@ class CheckDeprecatedDependency(FilePlugin):
                         if dependency_deprecated:
                             yield LinterError(
                                 f"VT depends on {dep}, which is marked "
-                                "as deprecated."
+                                "as deprecated.",
+                                file=self.context.nasl_file,
+                                plugin=self.name,
                             )

--- a/troubadix/plugins/deprecated_functions.py
+++ b/troubadix/plugins/deprecated_functions.py
@@ -57,5 +57,7 @@ class CheckDeprecatedFunctions(FilePlugin):
         for description, pattern in deprecated_functions.items():
             if re.search(pattern, self.context.file_content):
                 yield LinterError(
-                    f"Found a deprecated function call: {description}"
+                    f"Found a deprecated function call: {description}",
+                    file=self.context.nasl_file,
+                    plugin=self.name,
                 )

--- a/troubadix/plugins/description.py
+++ b/troubadix/plugins/description.py
@@ -39,5 +39,7 @@ class CheckDescription(FilePlugin):
         ).search(self.context.file_content)
         if script_description:
             yield LinterError(
-                "VT/Include is using deprecated 'script_description'"
+                "VT/Include is using deprecated 'script_description'",
+                file=self.context.nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/double_end_points.py
+++ b/troubadix/plugins/double_end_points.py
@@ -63,5 +63,7 @@ class CheckDoubleEndPoints(FilePlugin):
                         yield LinterError(
                             f"The script tag '{tag_match.group('name')}' "
                             "is ending with two or more points: "
-                            f"'{tag_match.group('value')}'."
+                            f"'{tag_match.group('value')}'.",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )

--- a/troubadix/plugins/duplicated_script_tags.py
+++ b/troubadix/plugins/duplicated_script_tags.py
@@ -46,11 +46,14 @@ class CheckDuplicatedScriptTags(FilePlugin):
                     continue
                 if tag.value == "xref":
                     continue
+
                 match = list(match)
                 if len(match) > 1:
                     yield LinterError(
                         f"The VT is using the script tag 'script_"
-                        f"{tag.value}' multiple number of times."
+                        f"{tag.value}' multiple number of times.",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )
 
         script_tag_patterns = get_script_tag_patterns()
@@ -62,5 +65,7 @@ class CheckDuplicatedScriptTags(FilePlugin):
                 if len(match) > 1:
                     yield LinterError(
                         f"The VT is using the script tag '{tag.value}' "
-                        "multiple number of times."
+                        "multiple number of times.",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/forking_nasl_functions.py
+++ b/troubadix/plugins/forking_nasl_functions.py
@@ -114,7 +114,9 @@ class CheckForkingNaslFunctions(FileContentPlugin):
                         "multiple times or in conjunction with other "
                         "forking functions. Please either use get_app_port_from"
                         "_list() from host_details.inc or split your VT into "
-                        f"several VTs for each covered protocol."
+                        f"several VTs for each covered protocol.",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )
             return
 
@@ -139,10 +141,13 @@ class CheckForkingNaslFunctions(FileContentPlugin):
                     if any(e in str(nasl_file) for e in exceptions):
                         if "nofork:TRUE" in tag[0]:
                             continue
+
                     yield LinterError(
                         f"The VT is using the {tag[0]} multiple times or in "
                         "conjunction with other forking functions. Please use "
                         "e.g. get_app_version_and_location(), "
                         "get_app_version_and_location_from_list() or similar "
-                        "functions from host_details.inc."
+                        "functions from host_details.inc.",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/get_kb_on_services.py
+++ b/troubadix/plugins/get_kb_on_services.py
@@ -85,5 +85,7 @@ class CheckGetKBOnServices(FileContentPlugin):
                     yield LinterError(
                         f"The following get_kb_{kb_match.group('type')}() call"
                         " should use a function instead of a direct access to "
-                        f"the Services/KB key: {kb_match.group('value')}"
+                        f"the Services/KB key: {kb_match.group('value')}",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -86,7 +86,7 @@ class CheckGrammar(LineContentPlugin):
         """
         pattern = get_grammer_pattern()
 
-        for line in lines:
+        for nr, line in enumerate(lines, 1):
             match = pattern.search(line)
             if match:
                 if self.check_for_false_positives(
@@ -98,6 +98,7 @@ class CheckGrammar(LineContentPlugin):
                     f"VT/Include has the following grammar problem: {line}",
                     file=self.context.nasl_file,
                     plugin=self.name,
+                    line=nr,
                 )
 
     @staticmethod

--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -95,7 +95,9 @@ class CheckGrammar(LineContentPlugin):
                     continue
 
                 yield LinterError(
-                    "VT/Include has the following grammar problem: " f"{line}"
+                    f"VT/Include has the following grammar problem: {line}",
+                    file=self.context.nasl_file,
+                    plugin=self.name,
                 )
 
     @staticmethod

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -72,7 +72,9 @@ class CheckHttpLinksInTags(FilePlugin):
                                 "One script_tag in the VT is using a HTTP "
                                 "link/URL which should be moved to a separate "
                                 '\'script_xref(name:"URL", value:"");\''
-                                f" tag instead: '{tag_match.group(0)}'"
+                                f" tag instead: '{tag_match.group(0)}'",
+                                file=self.context.nasl_file,
+                                plugin=self.name,
                             )
 
     def contains_nvd_mitre_link_in_xref(self) -> Iterator[LinterResult]:
@@ -110,7 +112,9 @@ class CheckHttpLinksInTags(FilePlugin):
                         "The following script_xref is pointing "
                         "to Mitre/NVD which is already covered by the "
                         "script_cve_id. This is a redundant info and the "
-                        f"script_xref needs to be removed: {match.group(0)}"
+                        f"script_xref needs to be removed: {match.group(0)}",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )
 
     @staticmethod

--- a/troubadix/plugins/illegal_characters.py
+++ b/troubadix/plugins/illegal_characters.py
@@ -78,7 +78,9 @@ class CheckIllegalCharacters(FilePlugin):
                         )
                         self.new_file_content = file_content
                         yield LinterWarning(
-                            f"Found illegal character in {match.group(0)}"
+                            f"Found illegal character in {match.group(0)}",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )
 
     def fix(self) -> Iterator[LinterResult]:
@@ -89,4 +91,8 @@ class CheckIllegalCharacters(FilePlugin):
             self.new_file_content, encoding=CURRENT_ENCODING
         )
 
-        yield LinterFix("Replaced Illegal Characters.")
+        yield LinterFix(
+            "Replaced Illegal Characters.",
+            file=self.context.nasl_file,
+            plugin=self.name,
+        )

--- a/troubadix/plugins/log_messages.py
+++ b/troubadix/plugins/log_messages.py
@@ -51,10 +51,15 @@ class CheckLogMessages(FileContentPlugin):
             re.MULTILINE,
         )
         if log_match:
-            yield LinterError("The VT is using an empty log_message() function")
+            yield LinterError(
+                "The VT is using an empty log_message() function",
+                file=nasl_file,
+                plugin=self.name,
+            )
 
         if nasl_file.suffix == ".inc":
             return
+
         # Policy VTs might use both, security_message and log_message
         if "Policy/" in str(nasl_file):
             return
@@ -77,5 +82,7 @@ class CheckLogMessages(FileContentPlugin):
         )
         if log_match:
             yield LinterWarning(
-                "The VT is using a log_message in a VT with a severity"
+                "The VT is using a log_message in a VT with a severity",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/misplaced_compare_in_if.py
+++ b/troubadix/plugins/misplaced_compare_in_if.py
@@ -78,5 +78,7 @@ class CheckMisplacedCompareInIf(FilePlugin):
                 if misplaced_compare_match:
                     yield LinterError(
                         f"VT/Include is using a misplaced compare "
-                        f"within an if() call in {if_match.group(0)}"
+                        f"within an if() call in {if_match.group(0)}",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/missing_desc_exit.py
+++ b/troubadix/plugins/missing_desc_exit.py
@@ -63,9 +63,15 @@ class CheckMissingDescExit(FileContentPlugin):
             )
             if not submatch:
                 yield LinterError(
-                    "No mandatory exit(0); found in the description block."
+                    "No mandatory exit(0); found in the description block.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
 
             return
 
-        yield LinterError("No description block extracted/found.")
+        yield LinterError(
+            "No description block extracted/found.",
+            file=nasl_file,
+            plugin=self.name,
+        )

--- a/troubadix/plugins/missing_tag_solution.py
+++ b/troubadix/plugins/missing_tag_solution.py
@@ -47,9 +47,11 @@ class CheckMissingTagSolution(FileContentPlugin):
         """
         if is_ignore_file(nasl_file, _IGNORE_FILES):
             return
+
         # Not all VTs have/require a solution_type text
         if "solution_type" not in file_content:
             return
+
         # Avoid unnecessary message against deprecated VTs.
         deprecated_pattern = get_script_tag_pattern(ScriptTag.DEPRECATED)
         deprecated_match = deprecated_pattern.search(string=file_content)
@@ -68,5 +70,7 @@ class CheckMissingTagSolution(FileContentPlugin):
         if not solution_match or solution_match.group(0) is None:
             yield LinterError(
                 "'solution_type' script_tag but no 'solution' script_tag "
-                "found in the description block."
+                "found in the description block.",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/newlines.py
+++ b/troubadix/plugins/newlines.py
@@ -51,7 +51,11 @@ class CheckNewlines(FilePlugin):
             if whitespaces_match:
                 for i in range(1, 5):
                     if whitespaces_match.group(f"w{i}") != "":
-                        yield LinterError(f"Found whitespaces in script_{tag}.")
+                        yield LinterError(
+                            f"Found whitespaces in script_{tag}.",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
+                        )
                         break
 
             newline_match = re.search(
@@ -61,5 +65,7 @@ class CheckNewlines(FilePlugin):
             )
             if newline_match:
                 yield LinterError(
-                    f"Found a newline within the tag script_{tag}."
+                    f"Found a newline within the tag script_{tag}.",
+                    file=self.context.nasl_file,
+                    plugin=self.name,
                 )

--- a/troubadix/plugins/no_solution.py
+++ b/troubadix/plugins/no_solution.py
@@ -23,7 +23,6 @@ from troubadix.helper import (
     CURRENT_ENCODING,
     ScriptTag,
     get_script_tag_pattern,
-    get_path_from_root,
 )
 from troubadix.plugin import (
     LinterError,
@@ -56,7 +55,6 @@ class CheckNoSolution(FilesPlugin):
             if nasl_file.suffix == ".inc":
                 continue
 
-            file_name = get_path_from_root(nasl_file, self.context.root)
             content = nasl_file.read_text(encoding=CURRENT_ENCODING)
             solution_match = get_script_tag_pattern(ScriptTag.SOLUTION).search(
                 content
@@ -67,7 +65,9 @@ class CheckNoSolution(FilesPlugin):
                     r"as\s+of\s*(?P<date>.+?)\.\s*", re.DOTALL
                 ).search(solution_match.group("value"))
             else:
-                yield LinterError(f"{file_name}: No Solution tag found.")
+                yield LinterError(
+                    "No Solution tag found.", file=nasl_file, plugin=self.name
+                )
                 continue
 
             # total number of missing solutions
@@ -79,8 +79,9 @@ class CheckNoSolution(FilesPlugin):
             no_solution_since = parse_date(date_match.group("date"))
             if not no_solution_since:
                 yield LinterError(
-                    f"{file_name}: Can not convert "
-                    f"'{date_match.group('date')}' to datetime"
+                    f"Can not convert '{date_match.group('date')}' to datetime",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
                 continue
 
@@ -88,7 +89,9 @@ class CheckNoSolution(FilesPlugin):
             if no_solution_since <= NO_SOLUTION_DATE_TOO_OLDER_1_YEAR:
                 missing_solutions_older_than_1_year += 1
                 yield LinterWarning(
-                    f"{file_name}: Missing solution, older than 1 year."
+                    "Missing solution, older than 1 year.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
                 continue
 
@@ -96,7 +99,9 @@ class CheckNoSolution(FilesPlugin):
             if no_solution_since <= NO_SOLUTION_DATE_TOO_OLDER_6_MONTH:
                 missing_solutions_older_than_6_months += 1
                 yield LinterWarning(
-                    f"{file_name}: Missing solution, older than 6 months."
+                    "Missing solution, older than 6 months.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
                 continue
 
@@ -104,24 +109,30 @@ class CheckNoSolution(FilesPlugin):
             if no_solution_since >= NO_SOLUTION_DATE_TOO_YOUNG:
                 missing_solutions_younger_1_month += 1
                 yield LinterWarning(
-                    f"{file_name}: Missing solution, but younger than 31 days."
+                    "Missing solution, but younger than 31 days.",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
 
         if total_missing_solutions > 0:
             yield LinterWarning(
-                "total missing solutions:" f" {total_missing_solutions}"
+                "total missing solutions:" f" {total_missing_solutions}",
+                plugin=self.name,
             )
             yield LinterWarning(
                 "missing solutions younger 1 month:"
-                f" {missing_solutions_younger_1_month}"
+                f" {missing_solutions_younger_1_month}",
+                plugin=self.name,
             )
             yield LinterWarning(
                 "missing solutions older than 6 months:"
-                f" {missing_solutions_older_than_6_months}"
+                f" {missing_solutions_older_than_6_months}",
+                plugin=self.name,
             )
             yield LinterWarning(
                 "missing solutions older than 1 year:"
-                f" {missing_solutions_older_than_1_year}"
+                f" {missing_solutions_older_than_1_year}",
+                plugin=self.name,
             )
 
 

--- a/troubadix/plugins/overlong_script_tags.py
+++ b/troubadix/plugins/overlong_script_tags.py
@@ -64,5 +64,7 @@ class CheckOverlongScriptTags(FileContentPlugin):
                     yield LinterError(
                         f"Tag {tag.value} is to long"
                         f" with {len(match.group('value'))} characters. "
-                        f"Max {VALUE_LIMIT}"
+                        f"Max {VALUE_LIMIT}",
+                        file=nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/prod_svc_detect_in_vulnvt.py
+++ b/troubadix/plugins/prod_svc_detect_in_vulnvt.py
@@ -77,7 +77,9 @@ class CheckProdSvcDetectInVulnvt(FilePlugin):
                 "VT has a severity but is placed in the family '"
                 f"{match_family.group('value')}' which is not allowed for this "
                 "VT. Please split this VT into a separate Product/Service "
-                "detection and Vulnerability-VT."
+                "detection and Vulnerability-VT.",
+                file=self.context.nasl_file,
+                plugin=self.name,
             )
 
         matches = re.finditer(
@@ -100,5 +102,7 @@ class CheckProdSvcDetectInVulnvt(FilePlugin):
                         "VT has a severity but is using the function '"
                         f"{match.group('function')}' which is not allowed for "
                         "this VT. Please split this VT into a separate "
-                        "Product/Service detection and Vulnerability-VT."
+                        "Product/Service detection and Vulnerability-VT.",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/qod.py
+++ b/troubadix/plugins/qod.py
@@ -68,9 +68,17 @@ class CheckQod(FilePlugin):
 
         num_matches = len(match_qod) + len(match_qod_type)
         if num_matches < 1:
-            yield LinterError("VT is missing QoD or QoD type")
+            yield LinterError(
+                "VT is missing QoD or QoD type",
+                file=self.context.nasl_file,
+                plugin=self.name,
+            )
         if num_matches > 1:
-            yield LinterError("VT contains multiple QoD values")
+            yield LinterError(
+                "VT contains multiple QoD values",
+                file=self.context.nasl_file,
+                plugin=self.name,
+            )
 
         for match in match_qod:
             try:
@@ -79,13 +87,17 @@ class CheckQod(FilePlugin):
                     yield LinterError(
                         f"{match.group(0)}: '{qod}' is an invalid QoD number"
                         " value. Allowed are"
-                        f" {', '.join(str(x) for x in VALID_QOD_NUM_VALUES)}"
+                        f" {', '.join(str(x) for x in VALID_QOD_NUM_VALUES)}",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )
             except ValueError:
                 yield LinterError(
                     f"{match.group(0)}: '{match.group('value')}' is an invalid"
                     " QoD number value. Allowed are"
-                    f" {', '.join(str(x) for x in VALID_QOD_NUM_VALUES)}"
+                    f" {', '.join(str(x) for x in VALID_QOD_NUM_VALUES)}",
+                    file=self.context.nasl_file,
+                    plugin=self.name,
                 )
 
         for match in match_qod_type:
@@ -93,5 +105,7 @@ class CheckQod(FilePlugin):
             if val not in VALID_QOD_TYPES:
                 yield LinterError(
                     f"{match.group(0)}: '{match.group('value')}' is an invalid"
-                    f" QoD type. Allowed are {', '.join(VALID_QOD_TYPES)}"
+                    f" QoD type. Allowed are {', '.join(VALID_QOD_TYPES)}",
+                    file=self.context.nasl_file,
+                    plugin=self.name,
                 )

--- a/troubadix/plugins/reporting_consistency.py
+++ b/troubadix/plugins/reporting_consistency.py
@@ -52,15 +52,23 @@ class CheckReportingConsistency(FileContentPlugin):
         cvss_base = cvss_base_pattern.search(file_content)
 
         if not cvss_base:
-            yield LinterError("VT/Include has no cvss_base tag")
+            yield LinterError(
+                "VT/Include has no cvss_base tag",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         if log_message and cvss_base.group("value") != "0.0":
             yield LinterError(
-                "Tag cvss_base is not 0.0 use report function security_message"
+                "Tag cvss_base is not 0.0 use report function security_message",
+                file=nasl_file,
+                plugin=self.name,
             )
 
         if security_message and cvss_base.group("value") == "0.0":
             yield LinterError(
-                "Tag cvss_base is 0.0 use report function log_message"
+                "Tag cvss_base is 0.0 use report function log_message",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/risk_factor.py
+++ b/troubadix/plugins/risk_factor.py
@@ -36,5 +36,7 @@ class CheckRiskFactor(FilePlugin):
             return
 
         yield LinterError(
-            f'Deprecated function "risk factor" found: {match.group("risk")}'
+            f'Deprecated function "risk factor" found: {match.group("risk")}',
+            file=self.context.nasl_file,
+            plugin=self.name,
         )

--- a/troubadix/plugins/script_add_preference_type.py
+++ b/troubadix/plugins/script_add_preference_type.py
@@ -86,5 +86,7 @@ class CheckScriptAddPreferenceType(FileContentPlugin):
                         "VT is using an invalid or misspelled string "
                         f"({pref_type}) passed to the type parameter of "
                         "script_add_preference in "
-                        f"'{preferences_match.group(0)}'"
+                        f"'{preferences_match.group(0)}'",
+                        file=nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/script_calls_empty_values.py
+++ b/troubadix/plugins/script_calls_empty_values.py
@@ -42,14 +42,26 @@ class CheckScriptCallsEmptyValues(FileContentPlugin):
 
         matches = _get_tag_pattern(name=r".*", value=r"").finditer(file_content)
         for match in matches:
-            yield LinterError(f"{match.group(0)} does not contain a value")
+            yield LinterError(
+                f"{match.group(0)} does not contain a value",
+                file=nasl_file,
+                plugin=self.name,
+            )
 
         matches = get_xref_pattern(name=r".*", value=r"").finditer(file_content)
         for match in matches:
-            yield LinterError(f"{match.group(0)} does not contain a value")
+            yield LinterError(
+                f"{match.group(0)} does not contain a value",
+                file=nasl_file,
+                plugin=self.name,
+            )
 
         matches = _get_special_script_tag_pattern(
             name=r"(?!add_preferences).*", value=""
         ).finditer(file_content)
         for match in matches:
-            yield LinterError(f"{match.group(0)} does not contain a value")
+            yield LinterError(
+                f"{match.group(0)} does not contain a value",
+                file=nasl_file,
+                plugin=self.name,
+            )

--- a/troubadix/plugins/script_calls_mandatory.py
+++ b/troubadix/plugins/script_calls_mandatory.py
@@ -57,5 +57,7 @@ class CheckScriptCallsMandatory(FileContentPlugin):
             if not get_special_script_tag_pattern(call).search(file_content):
                 yield LinterError(
                     "VT does not contain the following mandatory call: "
-                    f"'script_{call}'"
+                    f"'script_{call}'",
+                    file=nasl_file,
+                    plugin=self.name,
                 )

--- a/troubadix/plugins/script_calls_recommended.py
+++ b/troubadix/plugins/script_calls_recommended.py
@@ -73,7 +73,9 @@ class CheckScriptCallsRecommended(FileContentPlugin):
         ).search(file_content):
             yield LinterWarning(
                 "VT contains none of the following recommended calls: "
-                f"{', '.join(recommended_many_call)}"
+                f"{', '.join(recommended_many_call)}",
+                file=nasl_file,
+                plugin=self.name,
             )
         for call in recommended_single_call:
             if not _get_special_script_tag_pattern(
@@ -81,5 +83,7 @@ class CheckScriptCallsRecommended(FileContentPlugin):
             ).search(file_content):
                 yield LinterWarning(
                     "VT does not contain the following recommended call: "
-                    f"'script_{call}'"
+                    f"'script_{call}'",
+                    file=nasl_file,
+                    plugin=self.name,
                 )

--- a/troubadix/plugins/script_category.py
+++ b/troubadix/plugins/script_category.py
@@ -41,7 +41,11 @@ class CheckScriptCategory(FileContentPlugin):
         )
 
         if own_category_match is None or own_category_match.group(1) is None:
-            yield LinterError("VT is missing a script_category.")
+            yield LinterError(
+                "VT is missing a script_category.",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         # pylint: disable=line-too-long
@@ -50,6 +54,8 @@ class CheckScriptCategory(FileContentPlugin):
         own_category = own_category_match.group(1)
         if own_category not in SCRIPT_CATEGORIES:
             yield LinterError(
-                f"VT is using an unsupported category '{own_category}'."
+                f"VT is using an unsupported category '{own_category}'.",
+                file=nasl_file,
+                plugin=self.name,
             )
             return

--- a/troubadix/plugins/script_copyright.py
+++ b/troubadix/plugins/script_copyright.py
@@ -45,7 +45,9 @@ class CheckScriptCopyright(FileContentPlugin):
                 "The VT is using an incorrect syntax for its "
                 "copyright statement. Please start (EXACTLY) with: "
                 "'script_copyright(\"Copyright (C)' followed by the year "
-                "(matching the one in creation_date) and the author/company."
+                "(matching the one in creation_date) and the author/company.",
+                file=nasl_file,
+                plugin=self.name,
             )
 
         if re.search(
@@ -63,5 +65,7 @@ class CheckScriptCopyright(FileContentPlugin):
                 "statement. Please use (EXACTLY): "
                 "# Some text descriptions might be excerpted from (a) "
                 "referenced\n# source(s), and are Copyright (C) by the "
-                "respective right holder(s)."
+                "respective right holder(s).",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/script_family.py
+++ b/troubadix/plugins/script_family.py
@@ -106,15 +106,25 @@ class CheckScriptFamily(FileContentPlugin):
         matches = list(family_pattern.finditer(file_content))
 
         if not matches:
-            yield LinterError("No script family exist")
+            yield LinterError(
+                "No script family exist",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         if len(matches) > 1:
-            yield LinterError("More then one script family exist")
+            yield LinterError(
+                "More then one script family exist",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         if matches[0].group("value") not in VALID_FAMILIES:
             yield LinterError(
                 "Invalid or misspelled script family "
-                f"'{matches[0].group('value')}'"
+                f"'{matches[0].group('value')}'",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/script_tag_form.py
+++ b/troubadix/plugins/script_tag_form.py
@@ -46,5 +46,7 @@ class CheckScriptTagForm(FileContentPlugin):
                 ):
                     yield LinterError(
                         f"{match.group(0)}: does not conform to"
-                        ' script_tag(name:"<name>", value:<value>);'
+                        ' script_tag(name:"<name>", value:<value>);',
+                        file=nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/script_tag_whitespaces.py
+++ b/troubadix/plugins/script_tag_whitespaces.py
@@ -48,5 +48,7 @@ class CheckScriptTagWhitespaces(FileContentPlugin):
             ):
                 yield LinterError(
                     f"{match.group(0)}: value contains a leading or"
-                    " trailing whitespace character"
+                    " trailing whitespace character",
+                    file=nasl_file,
+                    plugin=self.name,
                 )

--- a/troubadix/plugins/script_version_and_last_modification_tags.py
+++ b/troubadix/plugins/script_version_and_last_modification_tags.py
@@ -56,9 +56,9 @@ class CheckScriptVersionAndLastModificationTags(FileContentPlugin):
 
         if not match_ver_modified:
             yield LinterError(
-                f"VT '{str(nasl_file)}' is missing "
-                "script_version(); or "
-                "is using a wrong syntax.\n"
+                "VT is missing script_version(); or is using a wrong syntax.",
+                file=nasl_file,
+                plugin=self.name,
             )
 
         # script_tag(name:"last_modification",
@@ -70,7 +70,9 @@ class CheckScriptVersionAndLastModificationTags(FileContentPlugin):
 
         if not match_last_modified:
             yield LinterError(
-                f"VT '{str(nasl_file)}' is missing script_tag("
+                "VT is missing script_tag("
                 'name:"last_modification" or is using a wrong '
-                "syntax.\n"
+                "syntax.",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/script_xref_form.py
+++ b/troubadix/plugins/script_xref_form.py
@@ -47,5 +47,7 @@ class CheckScriptXrefForm(FileContentPlugin):
                     ):
                         yield LinterError(
                             f"{match.group(0)}: does not conform to"
-                            ' script_xref(name:"<name>", value:<value>);'
+                            ' script_xref(name:"<name>", value:<value>);',
+                            file=nasl_file,
+                            plugin=self.name,
                         )

--- a/troubadix/plugins/script_xref_url.py
+++ b/troubadix/plugins/script_xref_url.py
@@ -43,4 +43,8 @@ class CheckScriptXrefUrl(FileContentPlugin):
         for match in matches:
             if match:
                 if not url(match.group("value")):
-                    yield LinterError(f"{match.group(0)}: Invalid URL value")
+                    yield LinterError(
+                        f"{match.group(0)}: Invalid URL value",
+                        file=nasl_file,
+                        plugin=self.name,
+                    )

--- a/troubadix/plugins/security_messages.py
+++ b/troubadix/plugins/security_messages.py
@@ -68,5 +68,7 @@ class CheckSecurityMessages(FileContentPlugin):
 
         if sec_match:
             yield LinterError(
-                "VT is using a security_message in a VT without severity"
+                "VT is using a security_message in a VT without severity",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/set_get_kb_calls.py
+++ b/troubadix/plugins/set_get_kb_calls.py
@@ -63,7 +63,9 @@ class CheckWrongSetGetKBCalls(FilePlugin):
                     if not set_param_match or len(set_param_match) != 2:
                         yield LinterError(
                             "The VT/Include is missing a 'name:' and/or "
-                            f"'value:' parameter: {set_match.group(0)}"
+                            f"'value:' parameter: {set_match.group(0)}",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )
 
         get_matches = re.finditer(
@@ -76,5 +78,7 @@ class CheckWrongSetGetKBCalls(FilePlugin):
                     if get_param_match and len(get_param_match) > 0:
                         yield LinterError(
                             "The VT/Include is using a non-existent 'name:' "
-                            f"and/or 'value:' parameter: {get_match.group(0)}"
+                            f"and/or 'value:' parameter: {get_match.group(0)}",
+                            file=self.context.nasl_file,
+                            plugin=self.name,
                         )

--- a/troubadix/plugins/solution_text.py
+++ b/troubadix/plugins/solution_text.py
@@ -104,6 +104,8 @@ class CheckSolutionText(FilePlugin):
                 "The VT with solution type 'NoneAvailable' is using an "
                 "incorrect syntax in the solution text. Please use "
                 f"(EXACTLY):\n{correct_none_available_syntax}",
+                file=self.context.nasl_file,
+                plugin=self.name,
             )
         elif _get_tag_pattern(
             name=ScriptTag.SOLUTION_TYPE.value, value="WillNotFix"
@@ -114,4 +116,6 @@ class CheckSolutionText(FilePlugin):
                 "The VT with solution type 'WillNotFix' is using an incorrect "
                 "syntax in the solution text. Please use one of these "
                 f"(EXACTLY):\n{correct_will_not_fix_syntax}",
+                file=self.context.nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/solution_type.py
+++ b/troubadix/plugins/solution_type.py
@@ -67,9 +67,13 @@ class CheckSolutionType(FileContentPlugin):
         if has_severity:
             if match is None or match.group(1) is None:
                 yield LinterError(
-                    f"VT {nasl_file} does not contain a solution_type"
+                    "VT does not contain a solution_type",
+                    file=nasl_file,
+                    plugin=self.name,
                 )
         if match is not None and match.group(2) not in VALUES:
             yield LinterError(
-                f"VT {nasl_file} does not contain a valid solution_type 'value'"
+                "VT does not contain a valid solution_type 'value'",
+                file=nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -51,7 +51,9 @@ class CheckSpelling(FilePlugin):
             yield LinterError(
                 "codespell tool not found within your PATH. Please install it "
                 "via e.g. 'pip3 install codespell' or 'apt-get install "
-                "codespell' and make sure it is available within your PATH. "
+                "codespell' and make sure it is available within your PATH.",
+                file=self.context.nasl_file,
+                plugin=self.name,
             )
             return
 
@@ -186,6 +188,14 @@ class CheckSpelling(FilePlugin):
                 codespell += line + "\n"
 
         if codespell and "==>" in codespell:
-            yield LinterWarning(codespell)
+            yield LinterWarning(
+                codespell,
+                file=self.context.nasl_file,
+                plugin=self.name,
+            )
         elif codespell and "Traceback (most recent call last):" in codespell:
-            yield LinterError(codespell)
+            yield LinterError(
+                codespell,
+                file=self.context.nasl_file,
+                plugin=self.name,
+            )

--- a/troubadix/plugins/tabs.py
+++ b/troubadix/plugins/tabs.py
@@ -26,8 +26,11 @@ class CheckTabs(FilePlugin):
     def run(self) -> Iterator[LinterResult]:
         """This script checks if a VT is using one or
         more tabs instead of spaces."""
-        count = 1
-        for line in self.context.lines:
+        for nr, line in enumerate(self.context.lines, 1):
             if "\t" in line:
-                yield LinterError(f"Found tabs in line {count}.")
-            count += 1
+                yield LinterError(
+                    "VT uses tabs instead of spaces.",
+                    file=self.context.nasl_file,
+                    plugin=self.name,
+                    line=nr,
+                )

--- a/troubadix/plugins/todo_tbd.py
+++ b/troubadix/plugins/todo_tbd.py
@@ -49,6 +49,8 @@ class CheckTodoTbd(LineContentPlugin):
             match = re.search("##? *(TODO|TBD|@todo):?", line)
             if match is not None:
                 yield LinterWarning(
-                    f"VT {nasl_file} contains #TODO/TBD/@todo"
-                    f" keywords at line {index}"
+                    "VT contains #TODO/TBD/@todo keywords.",
+                    file=nasl_file,
+                    plugin=self.name,
+                    line=index,
                 )

--- a/troubadix/plugins/trailing_spaces_tabs.py
+++ b/troubadix/plugins/trailing_spaces_tabs.py
@@ -47,6 +47,8 @@ class CheckTrailingSpacesTabs(FilePlugin):
                     and spaces_tabs_match.group(0) is not None
                 ):
                     yield LinterError(
-                        "The VT has one or more trailing spaces and/or tabs!"
+                        "The VT has one or more trailing spaces and/or tabs!",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
                     )
                     return

--- a/troubadix/plugins/update_modification_date.py
+++ b/troubadix/plugins/update_modification_date.py
@@ -52,7 +52,9 @@ class UpdateModificationDate(FilePlugin):
         )
         if not match:
             yield LinterError(
-                "VT does not contain a modification day script tag."
+                "VT does not contain a modification day script tag.",
+                file=self.context.nasl_file,
+                plugin=self.name,
             )
             return
 
@@ -79,7 +81,11 @@ class UpdateModificationDate(FilePlugin):
             string=file_content,
         )
         if not match:
-            yield LinterError("VT does not contain a script version.")
+            yield LinterError(
+                "VT does not contain a script version.",
+                file=self.context.nasl_file,
+                plugin=self.name,
+            )
             return
 
         old_version = match.groups()[0]
@@ -98,7 +104,9 @@ class UpdateModificationDate(FilePlugin):
 
         yield LinterWarning(
             f"Outdated last_modification date. Was {old_datetime} "
-            f"and should be {correctly_formated_datetime}"
+            f"and should be {correctly_formated_datetime}",
+            file=self.context.nasl_file,
+            plugin=self.name,
         )
 
     def fix(self) -> Iterator[LinterResult]:
@@ -110,5 +118,7 @@ class UpdateModificationDate(FilePlugin):
             yield LinterFix(
                 f"Replaced modification_date {self.old_datetime} "
                 f"with {self.new_datetime} and script_version "
-                f"{self.old_version} with {self.new_version}."
+                f"{self.old_version} with {self.new_version}.",
+                file=self.context.nasl_file,
+                plugin=self.name,
             )

--- a/troubadix/plugins/using_display.py
+++ b/troubadix/plugins/using_display.py
@@ -104,12 +104,16 @@ class CheckUsingDisplay(FileContentPlugin):
                     and if_comment_match.group(0) is not None
                 ):
                     yield LinterWarning(
-                        f"VT '{nasl_file}' is using a display() function which "
+                        f"VT is using a display() function which "
                         f"is protected by a comment or an if statement at: "
-                        f"{dis_match}."
+                        f"{dis_match}.",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                 else:
                     yield LinterError(
-                        f"VT/Include '{nasl_file}' is using a display() "
-                        f"function at: {dis_match}"
+                        f"VT/Include is using a display() "
+                        f"function at: {dis_match}",
+                        file=nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -64,13 +64,21 @@ class CheckValidOID(FileContentPlugin):
         oid_pattern = get_special_script_tag_pattern(SpecialScriptTag.OID)
         oid_match = oid_pattern.search(file_content)
         if oid_match is None or oid_match.group("oid") is None:
-            yield LinterError("No valid script_oid() call found")
+            yield LinterError(
+                "No valid script_oid() call found",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         oid = oid_match.group("oid")
 
         if "1.3.6.1.4.1.25623.1." not in oid:
-            yield LinterError(f"script_oid() {invalid_oid} '{str(oid)}'")
+            yield LinterError(
+                f"script_oid() {invalid_oid} '{str(oid)}'",
+                file=nasl_file,
+                plugin=self.name,
+            )
             return
 
         # Vendor-specific OIDs
@@ -80,7 +88,11 @@ class CheckValidOID(FileContentPlugin):
             )
             family_match = family_pattern.search(file_content)
             if family_match is None or family_match.group("value") is None:
-                yield LinterError("VT is missing a script family!")
+                yield LinterError(
+                    "VT is missing a script family!",
+                    file=nasl_file,
+                    plugin=self.name,
+                )
                 return
 
             family = family_match.group("value")
@@ -90,7 +102,9 @@ class CheckValidOID(FileContentPlugin):
                 if family != f"Huawei EulerOS {family_template}":
                     yield LinterError(
                         f"script_oid() {is_using_reserved} EulerOS "
-                        f"'{str(oid)}'"
+                        f"'{str(oid)}'",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -103,7 +117,9 @@ class CheckValidOID(FileContentPlugin):
                     yield LinterError(
                         f"script_oid() {invalid_oid} '{str(oid)}' (EulerOS "
                         "pattern: 1.3.6.1.4.1.25623.1.1.2.[ADVISORY_YEAR]"
-                        ".[ADVISORY_ID])"
+                        ".[ADVISORY_ID])",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                 return
 
@@ -112,7 +128,9 @@ class CheckValidOID(FileContentPlugin):
                 if family != f"SuSE {family_template}":
                     yield LinterError(
                         f"script_oid() {is_using_reserved} SUSE SLES "
-                        f"'{str(oid)}'"
+                        f"'{str(oid)}'",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -125,7 +143,9 @@ class CheckValidOID(FileContentPlugin):
                     yield LinterError(
                         f"script_oid() {invalid_oid} '{str(oid)}' (SLES "
                         f"pattern: 1.3.6.1.4.1.25623.1.1.4.[ADVISORY_YEAR]"
-                        f".[ADVISORY_ID].[ADVISORY_REVISION])"
+                        f".[ADVISORY_ID].[ADVISORY_REVISION])",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                 return
 
@@ -133,7 +153,9 @@ class CheckValidOID(FileContentPlugin):
                 if family != f"Amazon Linux {family_template}":
                     yield LinterError(
                         f"script_oid() {is_using_reserved} Amazon Linux "
-                        f"'{str(oid)}'"
+                        f"'{str(oid)}'",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -145,7 +167,9 @@ class CheckValidOID(FileContentPlugin):
                     yield LinterError(
                         f"script_oid() {invalid_oid} '{str(oid)}' (Amazon "
                         "pattern: 1.3.6.1.4.1.25623.1.1.5.[ADVISORY_YEAR]"
-                        ".[ADVISORY_ID])"
+                        ".[ADVISORY_ID])",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                 return
 
@@ -153,7 +177,9 @@ class CheckValidOID(FileContentPlugin):
                 if family != f"Mageia Linux {family_template}":
                     yield LinterError(
                         f"script_oid() {is_using_reserved} Mageia Linux "
-                        f"'{str(oid)}'"
+                        f"'{str(oid)}'",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -166,7 +192,9 @@ class CheckValidOID(FileContentPlugin):
                     yield LinterError(
                         f"script_oid() {invalid_oid} '{str(oid)}' (Mageia "
                         "pattern: 1.3.6.1.4.1.25623.1.1.10.[ADVISORY_YEAR]"
-                        ".[ADVISORY_ID])"
+                        ".[ADVISORY_ID])",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                 return
             else:
@@ -178,7 +206,10 @@ class CheckValidOID(FileContentPlugin):
                     or vendor_number_match.group(1) is None
                 ):
                     yield LinterError(
-                        f"script_oid() {invalid_oid} '{str(oid)}' (last digits)"
+                        f"script_oid() {invalid_oid} '{str(oid)}' "
+                        "(last digits)",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -188,7 +219,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Debian {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Debian VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -196,7 +229,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"SuSE {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} SuSE VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -204,7 +239,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Amazon Linux {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Amazon Linux "
-                            f"VTs '{str(oid)}'"
+                            f"VTs '{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -212,7 +249,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Gentoo {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Gentoo VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -220,7 +259,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != "FreeBSD Local Security Checks":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} FreeBSD VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -228,7 +269,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Oracle Linux {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Oracle Linux "
-                            f"VTs '{str(oid)}'"
+                            f"VTs '{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -236,7 +279,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Fedora {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Fedora VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -244,7 +289,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Mageia Linux {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Mageia Linux "
-                            f"VTs '{str(oid)}'"
+                            f"VTs '{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -252,7 +299,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"RedHat {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} RedHat VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -260,7 +309,9 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Ubuntu {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Ubuntu VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
 
@@ -268,13 +319,17 @@ class CheckValidOID(FileContentPlugin):
                     if family != f"Slackware {family_template}":
                         yield LinterError(
                             f"script_oid() {is_using_reserved} Slackware VTs "
-                            f"'{str(oid)}'"
+                            f"'{str(oid)}'",
+                            file=nasl_file,
+                            plugin=self.name,
                         )
                         return
                 else:
                     yield LinterError(
                         f"script_oid() {invalid_oid} '{str(oid)}' (Vendor OID "
-                        "with unknown Vendor-Prefix)"
+                        "with unknown Vendor-Prefix)",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -285,7 +340,11 @@ class CheckValidOID(FileContentPlugin):
             name_patter = get_special_script_tag_pattern(SpecialScriptTag.NAME)
             name_match = name_patter.search(file_content)
             if not name_match or not name_match.group("value"):
-                yield LinterError("VT is missing a script name!")
+                yield LinterError(
+                    "VT is missing a script name!",
+                    file=nasl_file,
+                    plugin=self.name,
+                )
                 return
 
             name = name_match.group("value")
@@ -295,7 +354,9 @@ class CheckValidOID(FileContentPlugin):
                 if not name.startswith(f"Mozilla Firefox {security_template}"):
                     yield LinterError(
                         f"script_oid() {is_using_reserved} 'Firefox' ("
-                        f"{str(oid)})"
+                        f"{str(oid)})",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -309,6 +370,8 @@ class CheckValidOID(FileContentPlugin):
                         f"script_oid() {invalid_oid} '{str(oid)}' "
                         "(Firefox pattern: 1.3.6.1.4.1.25623.1.2.1."
                         "[ADVISORY_YEAR].[ADVISORY_ID])",
+                        file=nasl_file,
+                        plugin=self.name,
                     )
                     return
 
@@ -320,6 +383,8 @@ class CheckValidOID(FileContentPlugin):
         if oid_digit_match is None or oid_digit_match.group(1) is None:
             yield LinterError(
                 f"script_oid() {invalid_oid} '{str(oid)}' (last digits)",
+                file=nasl_file,
+                plugin=self.name,
             )
             return
 
@@ -364,10 +429,14 @@ class CheckValidOID(FileContentPlugin):
             yield LinterError(
                 f"script_oid() {invalid_oid} '{str(oid)}' (reserved OID "
                 "range not part of the official Feed)",
+                file=nasl_file,
+                plugin=self.name,
             )
             return
 
         yield LinterError(
             f"script_oid() {invalid_oid} "
             f"'{str(oid)}' (unassigned OID range)",
+            file=nasl_file,
+            plugin=self.name,
         )

--- a/troubadix/plugins/valid_script_tag_names.py
+++ b/troubadix/plugins/valid_script_tag_names.py
@@ -116,4 +116,6 @@ class CheckValidScriptTagNames(FileContentPlugin):
                     yield LinterError(
                         f"The script_tag name '{match.group('name')}' "
                         "is not allowed.",
+                        file=nasl_file,
+                        plugin=self.name,
                     )

--- a/troubadix/plugins/variable_assigned_in_if.py
+++ b/troubadix/plugins/variable_assigned_in_if.py
@@ -94,4 +94,8 @@ class CheckVariableAssignedInIf(FileContentPlugin):
                     lint_error = True
 
         if lint_error:
-            yield LinterError(output)
+            yield LinterError(
+                output,
+                file=nasl_file,
+                plugin=self.name,
+            )

--- a/troubadix/plugins/vt_placement.py
+++ b/troubadix/plugins/vt_placement.py
@@ -81,4 +81,6 @@ class CheckVTPlacement(FileContentPlugin):
 
         yield LinterError(
             f"VT should be placed in the root directory ({root}).",
+            file=nasl_file,
+            plugin=self.name,
         )


### PR DESCRIPTION
**What**:

Extend LinterResults to allow specifying more information where the result did occur namely:
* the plugin that did find the result
* the file where the result did occur
* the line in the content where the result has been found

Part of DEVOPS-207

**Why**:

Will allow to collect and order the results as needed for different use cases.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
