### PR TITLE
Script family check Rocky Linux addition

### DIFF
--- a/troubadix/plugins/script_family.py
+++ b/troubadix/plugins/script_family.py
@@ -71,6 +71,7 @@ VALID_FAMILIES = [
     "RPC",
     "Red Hat Local Security Checks",
     "Remote file access",
+    "Rocky Linux Local Security Checks",
     "SMTP problems",
     "SNMP",
     "SSL and TLS",


### PR DESCRIPTION
**What**:

Added the script family for Rocky Linux LSCs to the `script_family` check.

**Why**:

The `script_family` is new and would otherwise fail the QA check.
Also to maintain parity between troubadix and old QA

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
