### PR TITLE
Change: Don't run script_version()/last_modification plugin against .inc files

### DIFF
--- a/troubadix/plugins/script_version_and_last_modification_tags.py
+++ b/troubadix/plugins/script_version_and_last_modification_tags.py
@@ -48,6 +48,9 @@ class CheckScriptVersionAndLastModificationTags(FileContentPlugin):
             nasl_file: The VT that shall be checked
             file_content: The content of the VT that shall be checked
         """
+        if nasl_file.suffix == ".inc":
+            return
+
         # script_version("2019-03-21T12:19:01+0000");")
         version_pattern = get_special_script_tag_pattern(
             SpecialScriptTag.VERSION


### PR DESCRIPTION
**What**:

.inc files don't have these tags so checking them would cause false positives like seen here:

```
$ troubadix --files nasl/common/bad_ssh_host_keys.inc
ℹ Start linting 1 files ... 
ℹ Time elapsed: 0:00:00.274571
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_script_version_and_last_modification_tags         2        0
⚠ check_spelling                                          0        1
  -------------------------------------------------------------------
ℹ sum                                                     1        2
```

**Why**:

N/A

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
