### PR TITLE
Change: Report spelling problems as Error. Exclude one .inc file.

### DIFF
--- a/tests/plugins/test_spelling.py
+++ b/tests/plugins/test_spelling.py
@@ -16,7 +16,7 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from pathlib import Path
 
-from troubadix.plugin import LinterWarning
+from troubadix.plugin import LinterError
 from troubadix.plugins.spelling import CheckSpelling
 
 from . import PluginTestCase
@@ -46,7 +46,7 @@ class CheckSpellingTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 1)
-        self.assertIsInstance(results[0], LinterWarning)
+        self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             f"{nasl_file}:1: soltuion ==> solution\n"
             f"{nasl_file}:1: aviaalable ==> available\n"

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -23,7 +23,6 @@ from troubadix.plugin import (
     FilePlugin,
     LinterError,
     LinterResult,
-    LinterWarning,
 )
 
 PluginPath = Path(__file__).parent.resolve()
@@ -85,6 +84,11 @@ class CheckSpelling(FilePlugin):
                 # Same for a few other files:
                 if "smtp_AV_42zip_DoS.nasl" in line and re.search(
                     r"BA\s+==>\s+BY, BE", line
+                ):
+                    continue
+
+                if "bad_ssh_host_keys.inc" in line and re.search(
+                    r"ba\s+==>\s+by, be", line
                 ):
                     continue
 
@@ -188,7 +192,7 @@ class CheckSpelling(FilePlugin):
                 codespell += line + "\n"
 
         if codespell and "==>" in codespell:
-            yield LinterWarning(
+            yield LinterError(
                 codespell,
                 file=self.context.nasl_file,
                 plugin=self.name,


### PR DESCRIPTION
**What**:

- In the "old" QA step the .inc file was excluded via the `--skip` parameter of codespell, this seems to have been missed during the migration to Troubadix
- A spelling mistake should throw an error to fail the QA

**Why**:

N/A

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
