### PR TITLE
Fix: Exclusion in valid_oid.py

### DIFF
--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -403,6 +403,7 @@ class CheckValidOID(FileContentPlugin):
         exceptions = [
             "ossim_server_detect.nasl",
             "gsf/2018/vmware/gb_vmware_fusion_vmxnet3_"
+            "stack_memory_usage_vuln_macosx.nasl",
             "enterprise/2018/vmware/gb_vmware_fusion_vmxnet3_"
             "stack_memory_usage_vuln_macosx.nasl",
             "2008/asterisk_sdp_header_overflow.nasl",


### PR DESCRIPTION
**What**:

Running the plugin shows the following previously:

```
$ troubadix --include-tests check_valid_oid --file nasl/common/gsf/2018/vmware/gb_vmware_fusion_vmxnet3_stack_memory_usage_vuln_macosx.nasl -v
ℹ Start linting 1 files ... 
/path/to/nasl/common/gsf/2018/vmware/gb_vmware_fusion_vmxnet3_stack_memory_usage_vuln_macosx.nasl
ℹ Checking gsf/2018/vmware/gb_vmware_fusion_vmxnet3_stack_memory_usage_vuln_macosx.nasl (1/1)
ℹ     Results for plugin check_valid_oid
×         script_oid() is using an invalid OID '1.3.6.1.4.1.25623.1.0.8141330' (unassigned OID range)
ℹ Time elapsed: 0:00:00.015437
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_valid_oid                                         1        0
  -------------------------------------------------------------------
ℹ sum                                                     0        1
```

This happened because of a `,` which has been missed to be added in #160

**Why**:

Exclude an error for an OID which already exists since longer time in the feed and which can't be changed.

**How**:

Run the previously shown command before / after this MR

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
