### PR TITLE
Change: Make prerun Plugins in- and excludable

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -30,7 +30,9 @@ from troubadix.plugins import _PLUGINS
 from troubadix.plugins.badwords import CheckBadwords
 from troubadix.plugins.copyright_text import CheckCopyrightText
 from troubadix.plugins.cvss_format import CheckCVSSFormat
+from troubadix.plugins.duplicate_oid import CheckDuplicateOID
 from troubadix.plugins.missing_desc_exit import CheckMissingDescExit
+from troubadix.plugins.no_solution import CheckNoSolution
 from troubadix.reporter import Reporter
 from troubadix.runner import Runner, TroubadixException
 
@@ -148,7 +150,7 @@ class TestRunner(unittest.TestCase):
             / "runner"
             / "fail.nasl"
         )
-        included_plugins = [CheckCVSSFormat.name]
+        included_plugins = [CheckCVSSFormat.name, CheckNoSolution.name]
         runner = Runner(
             n_jobs=1,
             reporter=self._reporter,
@@ -161,7 +163,7 @@ class TestRunner(unittest.TestCase):
 
         self.assertFalse(sys_exit)
 
-        self.assertEqual(self._reporter._result_counts.error_count, 4)
+        self.assertEqual(self._reporter._result_counts.error_count, 3)
         self.assertEqual(self._reporter._result_counts.warning_count, 0)
         self.assertEqual(self._reporter._result_counts.fix_count, 0)
         self.assertEqual(
@@ -393,7 +395,9 @@ class TestRunner(unittest.TestCase):
 
     def test_runner_log_file(self):
         included_plugins = [
+            CheckDuplicateOID.name,
             CheckMissingDescExit.name,
+            CheckNoSolution.name,
         ]
         nasl_file = (
             _here
@@ -421,7 +425,8 @@ class TestRunner(unittest.TestCase):
 
         compare_content = (
             "\tPre-Run Plugins: check_duplicate_oid, check_no_solution\n"
-            "\tIncluded Plugins: check_missing_desc_exit\n"
+            "\tIncluded Plugins: check_duplicate_oid, check_missing_desc_exit"
+            ", check_no_solution\n"
             "\tRunning plugins: check_missing_desc_exit\n"
             "\n\nRun plugin check_duplicate_oid\n"
             "\tResults for plugin check_duplicate_oid\n"

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -117,8 +117,9 @@ _PRE_RUN_PLUGINS = [
 
 
 class Plugins:
-    def __init__(self, plugins: List[Plugin]):
+    def __init__(self, plugins: List[Plugin], prerun_plugins: List[Plugin]):
         self._plugins = plugins
+        self._prerun_plugins = prerun_plugins
 
     def __len__(self) -> int:
         return len(self._plugins)
@@ -126,10 +127,13 @@ class Plugins:
     def __iter__(self) -> Iterable[Plugin]:
         return iter(self._plugins)
 
+    def get_prerun_plugins(self) -> Iterable[Plugin]:
+        return self._prerun_plugins
+
 
 class UpdatePlugins(Plugins):
     def __init__(self):
-        super().__init__([UpdateModificationDate])
+        super().__init__([UpdateModificationDate], [])
 
 
 class StandardPlugins(Plugins):
@@ -138,7 +142,7 @@ class StandardPlugins(Plugins):
         excluded_plugins: List[str] = None,
         included_plugins: List[str] = None,
     ) -> None:
-        super().__init__(_PLUGINS)
+        super().__init__(_PLUGINS, _PRE_RUN_PLUGINS)
 
         if excluded_plugins:
             self._plugins = [
@@ -147,10 +151,22 @@ class StandardPlugins(Plugins):
                 if plugin.__name__ not in excluded_plugins
                 and plugin.name not in excluded_plugins
             ]
+            self._prerun_plugins = [
+                plugin
+                for plugin in self._prerun_plugins
+                if plugin.__name__ not in excluded_plugins
+                and plugin.name not in excluded_plugins
+            ]
         if included_plugins:
             self._plugins = [
                 plugin
-                for plugin in _PLUGINS
+                for plugin in self._plugins
+                if plugin.__name__ in included_plugins
+                or plugin.name in included_plugins
+            ]
+            self._prerun_plugins = [
+                plugin
+                for plugin in self._prerun_plugins
                 if plugin.__name__ in included_plugins
                 or plugin.name in included_plugins
             ]

--- a/troubadix/runner.py
+++ b/troubadix/runner.py
@@ -132,7 +132,7 @@ class Runner:
     def run(self, files: Iterable[Path]) -> bool:
         """The function that should be executed to run
         the Plugins over all files"""
-        if not len(self.plugins):
+        if not len(self.plugins) and not len(self.pre_run_plugins):
             raise TroubadixException("No Plugin found.")
 
         # print plugins that will be executed
@@ -144,8 +144,10 @@ class Runner:
         )
 
         start = datetime.datetime.now()
-        self._check_files(files)
-        self._check_single_files(files)
+        if len(self.pre_run_plugins):
+            self._check_files(files)
+        if len(self.plugins):
+            self._check_single_files(files)
 
         self._reporter.report_info(
             f"Time elapsed: {datetime.datetime.now() - start}"

--- a/troubadix/runner.py
+++ b/troubadix/runner.py
@@ -26,12 +26,7 @@ from troubadix.helper.patterns import (
     init_special_script_tag_patterns,
 )
 from troubadix.plugin import FilePluginContext, FilesPlugin, FilesPluginContext
-from troubadix.plugins import (
-    _PRE_RUN_PLUGINS,
-    Plugins,
-    StandardPlugins,
-    UpdatePlugins,
-)
+from troubadix.plugins import Plugins, StandardPlugins, UpdatePlugins
 from troubadix.reporter import Reporter
 from troubadix.results import FileResults
 
@@ -67,8 +62,7 @@ class Runner:
         )
         self._excluded_plugins = excluded_plugins
         self._included_plugins = included_plugins
-
-        self.pre_run_plugins = _PRE_RUN_PLUGINS
+        self.pre_run_plugins = self.plugins.get_prerun_plugins()
 
         self._reporter = reporter
         self._n_jobs = n_jobs
@@ -150,7 +144,6 @@ class Runner:
         )
 
         start = datetime.datetime.now()
-
         self._check_files(files)
         self._check_single_files(files)
 


### PR DESCRIPTION
**What**:

* The Prerun Plugins could not be in or excluded and ran every time troubadix has been executed, this is changed now.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

DEVOPS-237

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
