### PR TITLE
Fix: Mixed up error and warning sums

### DIFF
--- a/troubadix/reporter.py
+++ b/troubadix/reporter.py
@@ -212,14 +212,14 @@ class Reporter:
 
         if self._fix:
             self._term.info(
-                f"{'sum':48} {self._result_counts.warning_count:8}"
-                f" {self._result_counts.error_count:8}"
+                f"{'sum':48} {self._result_counts.error_count:8}"
+                f" {self._result_counts.warning_count:8}"
                 f" {self._result_counts.fix_count:8}"
             )
         else:
             self._term.info(
-                f"{'sum':48} {self._result_counts.warning_count:8}"
-                f" {self._result_counts.error_count:8}"
+                f"{'sum':48} {self._result_counts.error_count:8}"
+                f" {self._result_counts.warning_count:8}"
             )
 
     def _log_append(self, message: str):


### PR DESCRIPTION
**What**:

Looked like this:
```
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_no_solution                                     240       27
  -------------------------------------------------------------------
ℹ sum                                                    27      240
```

Now will look like this:
```
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_no_solution                                     240       27
  -------------------------------------------------------------------
ℹ sum                                                   240       27
```

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
