### PR TITLE
Change: Make reporting in valid OID plugin consistent.

### DIFF
--- a/tests/plugins/test_valid_oid.py
+++ b/tests/plugins/test_valid_oid.py
@@ -205,7 +205,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "Debian VTs '1.3.6.1.4.1.25623.1.1.1.2256'"
+                "Debian '1.3.6.1.4.1.25623.1.1.1.2256'"
             ),
             results[0].message,
         )
@@ -346,7 +346,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "Gentoo VTs '1.3.6.1.4.1.25623.1.1.6.2256'"
+                "Gentoo '1.3.6.1.4.1.25623.1.1.6.2256'"
             ),
             results[0].message,
         )
@@ -385,7 +385,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "FreeBSD VTs '1.3.6.1.4.1.25623.1.1.7.2256'"
+                "FreeBSD '1.3.6.1.4.1.25623.1.1.7.2256'"
             ),
             results[0].message,
         )
@@ -424,7 +424,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "Oracle Linux VTs '1.3.6.1.4.1.25623.1.1.8.2256'"
+                "Oracle Linux '1.3.6.1.4.1.25623.1.1.8.2256'"
             ),
             results[0].message,
         )
@@ -463,7 +463,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "Fedora VTs '1.3.6.1.4.1.25623.1.1.9.2256'"
+                "Fedora '1.3.6.1.4.1.25623.1.1.9.2256'"
             ),
             results[0].message,
         )
@@ -541,7 +541,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "RedHat VTs '1.3.6.1.4.1.25623.1.1.11.2256'"
+                "RedHat '1.3.6.1.4.1.25623.1.1.11.2256'"
             ),
             results[0].message,
         )
@@ -580,7 +580,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "Ubuntu VTs '1.3.6.1.4.1.25623.1.1.12.2256'"
+                "Ubuntu '1.3.6.1.4.1.25623.1.1.12.2256'"
             ),
             results[0].message,
         )

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -113,7 +113,7 @@ class CheckValidOID(FileContentPlugin):
             if vendor_number == "1":
                 if family != f"Debian {family_template}":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} Debian VTs "
+                        f"script_oid() {is_using_reserved} Debian "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,
@@ -199,7 +199,7 @@ class CheckValidOID(FileContentPlugin):
             elif vendor_number == "6":
                 if family != f"Gentoo {family_template}":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} Gentoo VTs "
+                        f"script_oid() {is_using_reserved} Gentoo "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,
@@ -209,7 +209,7 @@ class CheckValidOID(FileContentPlugin):
             elif vendor_number == "7":
                 if family != "FreeBSD Local Security Checks":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} FreeBSD VTs "
+                        f"script_oid() {is_using_reserved} FreeBSD "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,
@@ -220,7 +220,7 @@ class CheckValidOID(FileContentPlugin):
                 if family != f"Oracle Linux {family_template}":
                     yield LinterError(
                         f"script_oid() {is_using_reserved} Oracle Linux "
-                        f"VTs '{str(oid)}'",
+                        f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,
                     )
@@ -229,7 +229,7 @@ class CheckValidOID(FileContentPlugin):
             elif vendor_number == "9":
                 if family != f"Fedora {family_template}":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} Fedora VTs "
+                        f"script_oid() {is_using_reserved} Fedora "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,
@@ -264,7 +264,7 @@ class CheckValidOID(FileContentPlugin):
             elif vendor_number == "11":
                 if family != f"RedHat {family_template}":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} RedHat VTs "
+                        f"script_oid() {is_using_reserved} RedHat "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,
@@ -274,7 +274,7 @@ class CheckValidOID(FileContentPlugin):
             elif vendor_number == "12":
                 if family != f"Ubuntu {family_template}":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} Ubuntu VTs "
+                        f"script_oid() {is_using_reserved} Ubuntu "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,


### PR DESCRIPTION
**What**:

Some of the LSCs reporting had used the `VTs` suffix, others not (e.g. EulerOS). IMHO the `VTs` could be dropped so did that change accordingly.

**Why**:

Consistency

**How**:

:robot: 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
