### PR TITLE
Add allow list for duplicated script_dependencies

### DIFF
--- a/tests/plugins/test_duplicated_script_tags.py
+++ b/tests/plugins/test_duplicated_script_tags.py
@@ -101,8 +101,8 @@ class CheckDuplicatedScriptTagsTestCase(PluginTestCase):
     def test_excluded_dependencies(self):
         path = Path("gsf/PCIDSS/v2.0/PCI-DSS-2.0.nasl")
         content = (
-            'script_dependencies(name:"Test", type:"checkbox");\n'
-            'script_dependencies(name:"Test2", type:"checkbox");\n'
+            'script_dependencies("vt1.nasl", "vt2.nasl");\n'
+            'script_dependencies("vt3.nasl", "vt4.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content
@@ -116,8 +116,8 @@ class CheckDuplicatedScriptTagsTestCase(PluginTestCase):
     def test_not_excluded_dependencies(self):
         path = Path("v2.0/PCI-DSS-2.0.nasl")
         content = (
-            'script_dependencies(name:"Test", type:"checkbox");\n'
-            'script_dependencies(name:"Test2", type:"checkbox");\n'
+            'script_dependencies("vt1.nasl", "vt2.nasl");\n'
+            'script_dependencies("vt3.nasl", "vt4.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content

--- a/tests/plugins/test_duplicated_script_tags.py
+++ b/tests/plugins/test_duplicated_script_tags.py
@@ -97,3 +97,33 @@ class CheckDuplicatedScriptTagsTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 0)
+
+    def test_excluded_dependencies(self):
+        path = Path("gsf/PCIDSS/v2.0/PCI-DSS-2.0.nasl")
+        content = (
+            'script_dependencies(name:"Test", type:"checkbox");\n'
+            'script_dependencies(name:"Test2", type:"checkbox");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content
+        )
+        plugin = CheckDuplicatedScriptTags(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_not_excluded_dependencies(self):
+        path = Path("v2.0/PCI-DSS-2.0.nasl")
+        content = (
+            'script_dependencies(name:"Test", type:"checkbox");\n'
+            'script_dependencies(name:"Test2", type:"checkbox");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content
+        )
+        plugin = CheckDuplicatedScriptTags(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)

--- a/troubadix/plugins/duplicated_script_tags.py
+++ b/troubadix/plugins/duplicated_script_tags.py
@@ -24,6 +24,13 @@ from troubadix.helper.patterns import (
 from troubadix.plugin import FilePlugin, LinterError, LinterResult
 
 
+allowed_dup_dependencies = [
+    "GSHB/EL15/GSHB.nasl",
+    "gsf/PCIDSS/PCI-DSS.nasl",
+    "gsf/PCIDSS/v2.0/PCI-DSS-2.0.nasl",
+]
+
+
 class CheckDuplicatedScriptTags(FilePlugin):
     name = "check_duplicated_script_tags"
 
@@ -36,6 +43,11 @@ class CheckDuplicatedScriptTags(FilePlugin):
 
             if tag.name == "ADD_PREFERENCE":
                 continue
+
+            if tag.name == "DEPENDENCIES":
+                file_path = str(self.context.nasl_file)
+                if any(f in file_path for f in allowed_dup_dependencies):
+                    continue
 
             match = pattern.finditer(file_content)
 


### PR DESCRIPTION
**What**:Add allow list for duplicated script_dependencies

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Note that we shouldn't generally allow script_dependencies() multiple times (because this might be an error due to copy'n'paste or similar) but only for the existing exclusions AND the three VTs mentioned above (because they are some kind of a special case which is allowed for now because we know that the tag isn't used wrongly).
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
