### PR TITLE
Fix: Don't check .inc in prod_svc_detect_in_vulnvt.py to fix false positives.

### DIFF
--- a/troubadix/plugins/prod_svc_detect_in_vulnvt.py
+++ b/troubadix/plugins/prod_svc_detect_in_vulnvt.py
@@ -56,6 +56,9 @@ class CheckProdSvcDetectInVulnvt(FilePlugin):
             nasl_file: The VT that is going to be checked
             file_content: The content of the VT
         """
+        if self.context.nasl_file.suffix == ".inc":
+            return
+
         file_content = self.context.file_content
         # Don't need to check VTs having a cvss of 0.0
         cvss_base_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)


### PR DESCRIPTION
**What**:

As noticed in VTD-1540 the plugin had checked .inc files but this check is only valid for .nasl files.

**Why**:

Avoid false positives.

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
