### PR TITLE
Fix: Calculating path root in case of files in multiple directories

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -60,10 +60,8 @@ class IsEnterpriseFolderTestCase(unittest.TestCase):
 class GetRootTestCase(unittest.TestCase):
     def test_get_root(self):
         self.assertEqual(get_root(Path("/nasl/foo/bar")), Path("/nasl"))
-        self.assertEqual(
-            get_root(Path("/nasl/common/bar")), Path("/nasl/common")
-        )
-        self.assertEqual(get_root(Path("/nasl/21.04/bar")), Path("/nasl/21.04"))
-        self.assertEqual(get_root(Path("/nasl/22.04/bar")), Path("/nasl/22.04"))
+        self.assertEqual(get_root(Path("/nasl/common/bar")), Path("/nasl"))
+        self.assertEqual(get_root(Path("/nasl/21.04/bar")), Path("/nasl"))
+        self.assertEqual(get_root(Path("/nasl/22.04/bar")), Path("/nasl"))
         self.assertEqual(get_root(Path("/foo/bar")), Path("/"))
         self.assertEqual(get_root(Path("")), Path("/"))

--- a/troubadix/helper/helper.py
+++ b/troubadix/helper/helper.py
@@ -100,7 +100,7 @@ def get_root(path: Path) -> Path:
     """Get the root directory of the VTs"""
     path = path.resolve().absolute()
     for parent in path.parents:
-        if parent.name in ["", "nasl", "common", "21.04", "22.04"]:
+        if parent.name in ["", "nasl"]:
             return parent
 
     return path


### PR DESCRIPTION
**What**:

When checking files of different folders, troubadix breaks

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

* don't look for the subfolder (e.g. `common, 2010`) but for the folder `nasl` only ...

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
