### PR TITLE
Change: Update exclusion pattern in spelling.py

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -126,6 +126,7 @@ class CheckSpelling(FilePlugin):
                 if (
                     "PCIDSS/" in line
                     or "GSHB/" in line
+                    or "attic/PCIDSS_" in line
                     or "ITG_Kompendium/" in line
                 ):
                     if re.search(
@@ -143,7 +144,11 @@ class CheckSpelling(FilePlugin):
                 # string('\nIn the file sent\nin milliseconds
                 # There are too many hits to maintain them in codespell.exclude
                 # so exclude them for now here.
-                if "PCIDSS/" in line or "GSHB/" in line:
+                if (
+                    "PCIDSS/" in line
+                    or "GSHB/" in line
+                    or "attic/PCIDSS_" in line
+                ):
                     if re.search(r"n[iI]n\s+==>\s+inn", line):
                         continue
 


### PR DESCRIPTION
**What**:

Some of the VTs got deprecated recently and moved from e.g. `gsf/PCIDSS/PCIDSS_something.nasl` to `gsf/attic/PCIDSS_something.nasl` so the previous exclusion didn't worked anymore. Updated it now accordingly.

**Why**:

N/A

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
