### PR TITLE
Fix: Duplicated checks in copyright_text and script_copyright

### DIFF
--- a/tests/plugins/test_script_copyright.py
+++ b/tests/plugins/test_script_copyright.py
@@ -62,3 +62,41 @@ class CheckScriptCopyrightTestCase(PluginTestCase):
             "copyright statement.",
             results[0].message,
         )
+
+    def test_copyright_error2(self):
+        path = Path("some/file.nasl")
+        content = (
+            'script_copyright("This script is Copyright (C) 2020 Foo Bar")'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content
+        )
+        plugin = CheckScriptCopyright(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertIn(
+            "The VT is using an incorrect syntax for its "
+            "copyright statement.",
+            results[0].message,
+        )
+
+    def test_copyright_error3(self):
+        path = Path("some/file.nasl")
+        content = 'script_copyright("Copyright (c) 2020 Foo Bar")'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content
+        )
+        plugin = CheckScriptCopyright(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertIn(
+            "The VT is using an incorrect syntax for its "
+            "copyright statement.",
+            results[0].message,
+        )

--- a/troubadix/plugins/copyright_text.py
+++ b/troubadix/plugins/copyright_text.py
@@ -41,15 +41,8 @@ class CheckCopyrightText(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
-        """This step checks a VT for the correct use of the copyright text.
-
-        Prior to this step, most VTs are using
-        "This script is Copyright (C) [...]",
-        however the introductory text ("This script is") is to be discarded
-        from now on.
-
-        In addition it will also report any occurrence of the following
-        outdated text pattern:
+        """This plugin will report any occurrence of the following outdated text
+        pattern:
 
         # Text descriptions are largely excerpted from the referenced
         # advisory, and are Copyright (C) of their respective author(s)
@@ -78,18 +71,6 @@ class CheckCopyrightText(FileContentPlugin):
 
         if nasl_file.suffix == ".inc":
             return
-
-        if not re.search(
-            r'script_copyright\("Copyright \(C\) [0-9]{4}', file_content
-        ):
-            yield LinterError(
-                "The VT is using an incorrect syntax for its copyright "
-                "statement. Please start (EXACTLY) with:\n"
-                "'script_copyright(\"Copyright (C) followed by the year "
-                "(matching the one in creation_date) and the author/company.",
-                file=nasl_file,
-                plugin=self.name,
-            )
 
         match = re.search(
             r"^# (Text descriptions are largely excerpted from the referenced"

--- a/troubadix/plugins/script_copyright.py
+++ b/troubadix/plugins/script_copyright.py
@@ -30,7 +30,16 @@ class CheckScriptCopyright(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
-        """
+        """This plugin checks a VT for the correct use of the copyright text.
+
+        Prior to this plugin, most VTs had used a
+        'script_copyright("This script is Copyright (C) [...]");'
+        tag, however the introductory text ("This script is") is to be discarded
+        from now on.
+
+        In addition this plugin will also report if the syntax of the
+        'script_copyright();' tag is generally missing or malformed.
+
         Args:
             nasl_file: The VT that shall be checked
             file_content: str representing the file content
@@ -46,26 +55,6 @@ class CheckScriptCopyright(FileContentPlugin):
                 "copyright statement. Please start (EXACTLY) with: "
                 "'script_copyright(\"Copyright (C)' followed by the year "
                 "(matching the one in creation_date) and the author/company.",
-                file=nasl_file,
-                plugin=self.name,
-            )
-
-        if re.search(
-            r"^# (Text descriptions are largely excerpted from the "
-            r"referenced\n# advisory, and are Copyright "
-            r"\([cC]\) (of )?(the |their )respective author"
-            r"\(s\)|Some text descriptions might be excerpted "
-            r"from the referenced\n# advisories, and are Copyright \(C\) by "
-            r"the respective right holder\(s\))",
-            file_content,
-            re.MULTILINE,
-        ):
-            yield LinterError(
-                "The VT is using an incorrect copyright "
-                "statement. Please use (EXACTLY): "
-                "# Some text descriptions might be excerpted from (a) "
-                "referenced\n# source(s), and are Copyright (C) by the "
-                "respective right holder(s).",
                 file=nasl_file,
                 plugin=self.name,
             )


### PR DESCRIPTION
**What**:

While migrating/porting the "old" `check_copyright_text.py` to Troubadix it seems that it was tried to split the two checks in that step into two separate plugins but it was missed to remove the check from one plugin which had been covered in the other one causing duplicated results to be reported.

This PR should fix that by removing the check from the plugins which had been covered by the other plugin.

Notes:
- I have also added a few additional cases for one plugin test.
- I haven't put any additional work into the text output of `script_copyright.py` (Because e.g. it also reports if the `script_copyright()` is completely missing but this is currently not reflected in the output) because this tag will be deprecated and removed completely in the future anyway
- The unit test in `test_script_copyright.py` will most likely fail and it would be great to get some support by the @greenbone/devops team to get it updated because i'm not familiar with unit tests.

Related to: VTD-1534

**Why**:

Avoid duplicated reporting of the same error.

**How**:

Via the related / included unit tests.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
