### PR TITLE
Change: Update plugin name of risk_factor.py

### DIFF
--- a/troubadix/plugins/risk_factor.py
+++ b/troubadix/plugins/risk_factor.py
@@ -22,7 +22,7 @@ from troubadix.plugin import FilePlugin, LinterError, LinterResult
 
 
 class CheckRiskFactor(FilePlugin):
-    name = "risk_factor"
+    name = "check_risk_factor"
 
     def run(self) -> Iterator[LinterResult]:
         """This script checks if a VT with risk_factor tag exist."""


### PR DESCRIPTION
**What**:

All plugin names have included the `check_` prefix expect this one like seen here:

```
✓     No results for plugin check_reporting_consistency
✓     No results for plugin risk_factor
✓     No results for plugin check_script_category
✓     No results for plugin check_script_copyright
✓     No results for plugin check_script_family
```

**Why**:

Consistency reasons

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
