### PR TITLE
Change: Minor textual change in copyright_text.py plugin.

### DIFF
--- a/tests/plugins/test_copyright_text.py
+++ b/tests/plugins/test_copyright_text.py
@@ -86,7 +86,7 @@ class CheckCopyrightTextTestCase(PluginTestCase):
 
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "The VT was using an incorrect copyright statement.",
+            "The VT is using an incorrect copyright statement.",
             results[0].message,
         )
 
@@ -110,7 +110,7 @@ class CheckCopyrightTextTestCase(PluginTestCase):
 
             self.assertIsInstance(results[0], LinterError)
             self.assertEqual(
-                "The VT was using an incorrect copyright statement.",
+                "The VT is using an incorrect copyright statement.",
                 results[0].message,
             )
 
@@ -138,7 +138,7 @@ class CheckCopyrightTextTestCase(PluginTestCase):
 
                 self.assertIsInstance(results[0], LinterFix)
                 self.assertEqual(
-                    "The copyright has been updated to "
+                    "The copyright statement has been updated to "
                     f"{CORRECT_COPYRIGHT_PHRASE}",
                     results[0].message,
                 )

--- a/troubadix/plugins/copyright_text.py
+++ b/troubadix/plugins/copyright_text.py
@@ -88,7 +88,7 @@ class CheckCopyrightText(FileContentPlugin):
             )
 
             yield LinterError(
-                "The VT was using an incorrect copyright statement.",
+                "The VT is using an incorrect copyright statement.",
                 file=nasl_file,
                 plugin=self.name,
             )
@@ -103,7 +103,8 @@ class CheckCopyrightText(FileContentPlugin):
         )
 
         yield LinterFix(
-            f"The copyright has been updated to {CORRECT_COPYRIGHT_PHRASE}",
+            f"The copyright statement has been updated to "
+            f"{CORRECT_COPYRIGHT_PHRASE}",
             file=nasl_file,
             plugin=self.name,
         )


### PR DESCRIPTION
**What**:

1. If the is doing plugin reports the VT `is using` and not `was using` the incorrect copyright statement
2. If the plugin is doing the "fix" then there is a separate string noticing that the copyright statement has been update so the `was using` is IMHO still not required
3. The missing `statement` word was added for consistency reasons

Instead of `is using` we could also say `is/was using` but IMHO this is too much for such a minor thing.

**Why**:

Consistency reasons.

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
