### PR TITLE
Change: Exclude example and template files in reporting_consistency.py

### DIFF
--- a/troubadix/plugins/reporting_consistency.py
+++ b/troubadix/plugins/reporting_consistency.py
@@ -26,7 +26,10 @@ from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
 
 # nb: Those are files which are correctly using a log_message() to do e.g. some
 # additional reporting for the user. This is a valid case which doesn't need to
-# be changed.
+# be changed. The example and template files shouldn't be checked at all because
+# the plugin would throw an unecessary error for them if e.g. not running from
+# within the nasl/common folder. But all three files are just examples and don't
+# need to be checked at all.
 IGNORE_FILES = [
     "mssql_version.nasl",
     "pre2008/domino_default_db.nasl",
@@ -48,6 +51,9 @@ IGNORE_FILES = [
     "2015/gb_vnc_brute_force.nasl",
     "2012/gb_secpod_ssl_ciphers_weak_report.nasl",
     "GSHB/GSHB_Kompendium.nasl",
+    "/policy_control_template.nasl",
+    "/template.nasl",
+    "/examples/test_ipv6_packet_forgery.nasl",
 ]
 
 


### PR DESCRIPTION
**What**:

The example and template files shouldn't be checked at all because the plugin would throw an unecessary error for them if e.g. not running from within the nasl/common folder. But all three files are just examples and don't need to be checked at all.

- Closes: DEVOPS-277
- Related to: VTD-1541

**Why**:

Avoid unnecessary reporting for errors which are no real errors.

**How**:

Ran the following before / after this PR from within the main root dir of the vulnerability-tests repo (not from within `nasl/common`) to see that the reporting is now gone:

```
$ troubadix -f --include-tests check_reporting_consistency -v
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
