### PR TITLE
Change: Update text with more info in changed_oid.py plugin

### DIFF
--- a/troubadix/standalone_plugins/changed_oid.py
+++ b/troubadix/standalone_plugins/changed_oid.py
@@ -123,9 +123,11 @@ def check_oid(args: Namespace) -> bool:
 
         if oid_added.group("oid") != oid_removed.group("oid"):
             print(
-                f"Change OID IN {nasl_file} "
-                f"OID_NEW: {oid_added.group('oid')} "
-                f"OID OLD: {oid_removed.group('oid')}"
+                f"OID of VT {nasl_file} was changed. This is only allowed in "
+                f"rare cases (e.g. a duplicate OID got fixed or a single VT "
+                f"was split into two VTs)."
+                f"\nOID NEW: {oid_added.group('oid')}"
+                f"\nOID OLD: {oid_removed.group('oid')}"
             )
             rcode = True
     return rcode


### PR DESCRIPTION
**What**:

Before this PR the output looked like:

```
Check file nasl/common/sw_http_os_detection.nasl
Change OID IN nasl/common/sw_http_os_detection.nasl OID_NEW: 1.3.6.1.4.1.25623.1.0.111068 OID OLD: 1.3.6.1.4.1.25623.1.0.111067
```

which was now changed to the following:

```
OID of VT nasl/common/sw_http_os_detection.nasl was changed. This is only allowed in rare cases (e.g. a duplicate OID got fixed or a single VT was split into two VTs).
OID NEW: 1.3.6.1.4.1.25623.1.0.111068
OID OLD: 1.3.6.1.4.1.25623.1.0.111067
```

**Why**:

To stay a little bit closer to the output of the "old" step and to give more background info on this problem.

There was also a inconsistency in the output because in one part `OID_NEW` (with an underscore) was used while the other part had `OID OLD` (without an underscore).

**How**:

Change the OID of a VT locally and run the following afterwards:

```
troubadix-changed-oid -c HEAD~1
```

**Checklist**:

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
