### PR TITLE
Fix: Add missing space and full stop to help output.

### DIFF
--- a/troubadix/argparser.py
+++ b/troubadix/argparser.py
@@ -228,7 +228,7 @@ def parse_args(
         default=cpu_count() // 2,
         type=check_cpu_count,
         help=(
-            "Define number of jobs, that should run simultaneously"
+            "Define number of jobs, that should run simultaneously. "
             "Default: %(default)s"
         ),
     )


### PR DESCRIPTION
**What**:

Previously the output of `--help` looked like the following:

```
Define number of jobs, that should run simultaneouslyDefault: 2
```

This should be now the following instead:

```
Define number of jobs, that should run simultaneously. Default: 2
```

**Why**:

N/A

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
