### PR TITLE
Remove: Handling of unsupported script_id() tag.

### DIFF
--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -198,7 +198,6 @@ class SpecialScriptTag(Enum):
     MANDATORY_KEYS = "mandatory_keys"
     NAME = "name"
     OID = "oid"  # script_oid("1.3.6.1.4.1.25623.1.0.XXXXXX");
-    ID = "id"  # deprecated for OID but kept for backward compatibility
     REQUIRE_KEYS = "require_keys"
     REQUIRE_PORTS = "require_ports"
     REQUIRE_UDP_PORTS = "require_udp_ports"
@@ -235,7 +234,6 @@ __special_script_tag_patterns = None
 
 __special_script_tag_values = {
     SpecialScriptTag.OID: r"(?P<oid>([0-9.]+))",
-    SpecialScriptTag.ID: r"(?P<oid>([0-9.]+))",
     SpecialScriptTag.CATEGORY: r"(?P<category>("
     rf"{'|'.join([k for k, _ in SCRIPT_CATEGORIES.items()])}))",
     SpecialScriptTag.VERSION: r"[0-9\-\:\+T]{24}|\$Revision: [0-9]+ \$",

--- a/troubadix/plugins/duplicate_oid.py
+++ b/troubadix/plugins/duplicate_oid.py
@@ -51,19 +51,12 @@ class CheckDuplicateOID(FilesPlugin):
 
             oid = None
             content = nasl_file.read_text(encoding=CURRENT_ENCODING)
-            # search for deprecated script_id
             match = get_special_script_tag_pattern(SpecialScriptTag.OID).search(
                 content
             )
 
             if match:
                 oid = match.group("oid")
-            else:
-                match = get_special_script_tag_pattern(
-                    SpecialScriptTag.ID
-                ).search(content)
-                if match:
-                    oid = OPENVAS_OID_PREFIX + match.group("oid")
 
             if not oid:
                 yield LinterError(


### PR DESCRIPTION
**What**:

Remove any special handling of `script_id()` from Troubadix.

The `script_id()` itself is gone since quite some years with greenbone/openvas-scanner#54 and running a VT using it yields the following:

```
lib  nasl-Message: 08:24:56.287: [10679](oid.nasl:1) Undefined function 'script_id'

Error while processing oid.nasl.
1 scripts with one or more errors found
```

Furthermore `script_id()` is also already included in the `deprecated_functions.py` plugin and would be also reported by that if used.

**Why**:

Remove not required code.

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
