### PR TITLE
Fix: Special script tag name can not be a regex in script_calls_empty_values

### DIFF
--- a/tests/plugins/test_script_calls_empty_values.py
+++ b/tests/plugins/test_script_calls_empty_values.py
@@ -65,5 +65,5 @@ class CheckScriptCallsEmptyValuesTestCase(PluginTestCase):
 
         results = list(plugin.run())
 
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 2)
         self.assertIsInstance(results[0], LinterError)

--- a/troubadix/plugins/script_calls_empty_values.py
+++ b/troubadix/plugins/script_calls_empty_values.py
@@ -59,13 +59,13 @@ class CheckScriptCallsEmptyValues(FileContentPlugin):
             )
 
         for call in SpecialScriptTag:
+            if call == SpecialScriptTag.ADD_PREFERENCE:
+                continue
             # Special script tag name can not be a regex
             matches = _get_special_script_tag_pattern(
                 name=call.value, value=""
             ).finditer(file_content)
             for match in matches:
-                # if "script_add_preference" in match.group(0):
-                #    continue
                 yield LinterError(
                     f"{match.group(0)} does not contain a value",
                     file=nasl_file,

--- a/troubadix/plugins/script_calls_empty_values.py
+++ b/troubadix/plugins/script_calls_empty_values.py
@@ -61,7 +61,6 @@ class CheckScriptCallsEmptyValues(FileContentPlugin):
         for call in SpecialScriptTag:
             if call == SpecialScriptTag.ADD_PREFERENCE:
                 continue
-            # Special script tag name can not be a regex
             matches = _get_special_script_tag_pattern(
                 name=call.value, value=""
             ).finditer(file_content)

--- a/troubadix/plugins/script_calls_empty_values.py
+++ b/troubadix/plugins/script_calls_empty_values.py
@@ -22,9 +22,11 @@ from troubadix.helper.patterns import (
     _get_special_script_tag_pattern,
     _get_tag_pattern,
     get_xref_pattern,
-    SpecialScriptTag,
 )
 from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
+
+# For the future
+SPECIAL_SCRIPT_TAG_LIST = []
 
 
 class CheckScriptCallsEmptyValues(FileContentPlugin):
@@ -58,9 +60,7 @@ class CheckScriptCallsEmptyValues(FileContentPlugin):
                 plugin=self.name,
             )
 
-        for call in SpecialScriptTag:
-            if call == SpecialScriptTag.ADD_PREFERENCE:
-                continue
+        for call in SPECIAL_SCRIPT_TAG_LIST:
             matches = _get_special_script_tag_pattern(
                 name=call.value, value=""
             ).finditer(file_content)

--- a/troubadix/plugins/script_calls_empty_values.py
+++ b/troubadix/plugins/script_calls_empty_values.py
@@ -22,6 +22,7 @@ from troubadix.helper.patterns import (
     _get_special_script_tag_pattern,
     _get_tag_pattern,
     get_xref_pattern,
+    SpecialScriptTag,
 )
 from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
 
@@ -57,12 +58,16 @@ class CheckScriptCallsEmptyValues(FileContentPlugin):
                 plugin=self.name,
             )
 
-        matches = _get_special_script_tag_pattern(
-            name=r"(?!add_preferences).*", value=""
-        ).finditer(file_content)
-        for match in matches:
-            yield LinterError(
-                f"{match.group(0)} does not contain a value",
-                file=nasl_file,
-                plugin=self.name,
-            )
+        for call in SpecialScriptTag:
+            # Special script tag name can not be a regex
+            matches = _get_special_script_tag_pattern(
+                name=call.value, value=""
+            ).finditer(file_content)
+            for match in matches:
+                # if "script_add_preference" in match.group(0):
+                #    continue
+                yield LinterError(
+                    f"{match.group(0)} does not contain a value",
+                    file=nasl_file,
+                    plugin=self.name,
+                )


### PR DESCRIPTION
**What**:
Special script tag name can not be a regex in script_calls_empty_values. This leads to regex mismatches. Further only check script_tag and script_xref in script_calls_empty_values.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
- DEVOPS-291
- DEVOPS-286

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
