### PR TITLE
Fix: re.DOTALL is needed to get multiline tag values

### DIFF
--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -237,11 +237,11 @@ def get_special_script_tag_pattern(
 
 class CommonScriptTagsPattern:
     instance = False
-
+    # re.DOTALL is needed to get multiline tag values
     def __init__(self) -> None:
         self.pattern = _get_tag_pattern(
             name=r"(summary|impact|affected|insight|vuldetect|solution)",
-            flags=re.MULTILINE,
+            flags=re.MULTILINE | re.DOTALL,
         )
         self.instance = self
 


### PR DESCRIPTION
**What**:
Fix: re.DOTALL is needed to get multiline tag values
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Multiline tag values are needed by check_double_end_points
<!-- Why are these changes necessary? -->

> In the default mode, `.` matches any character except a newline. If the [DOTALL](https://docs.python.org/3/library/re.html#re.DOTALL) flag has been specified, this matches any character including a newline.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
