### PR TITLE
Fix: misspelled required_ports to require_ports

### DIFF
--- a/troubadix/plugins/script_calls_recommended.py
+++ b/troubadix/plugins/script_calls_recommended.py
@@ -62,7 +62,7 @@ class CheckScriptCallsRecommended(FileContentPlugin):
 
         recommended_single_call = [r"dependencies"]
         recommended_many_call = [
-            r"required_ports",
+            r"require_ports",
             r"require_udp_ports",
             r"require_keys",
             r"mandatory_keys",


### PR DESCRIPTION
**What**:Fix misspelled required_ports to require_ports in script_calls_recommended.py.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
