### PR TITLE
Change: Rework UpdateModificationDate into a "normal" plugin

### DIFF
--- a/tests/plugins/test_last_modification.py
+++ b/tests/plugins/test_last_modification.py
@@ -18,8 +18,8 @@
 from pathlib import Path
 
 from troubadix.helper import CURRENT_ENCODING
-from troubadix.plugin import LinterError, LinterFix, LinterWarning
-from troubadix.plugins.update_modification_date import UpdateModificationDate
+from troubadix.plugin import LinterError, LinterFix
+from troubadix.plugins.last_modification import CheckLastModification
 
 from . import PluginTestCase
 
@@ -32,11 +32,11 @@ class TestUpdateModificationDate(PluginTestCase):
         fake_context = self.create_file_plugin_context(
             nasl_file=nasl_file, file_content=content
         )
-        plugin = UpdateModificationDate(fake_context)
+        plugin = CheckLastModification(fake_context)
 
         results = list(plugin.run())
 
-        self.assertIsInstance(results[0], LinterWarning)
+        self.assertEqual(len(results), 0)
 
         results = list(plugin.fix())
 
@@ -55,7 +55,7 @@ class TestUpdateModificationDate(PluginTestCase):
         fake_context = self.create_file_plugin_context(
             nasl_file=nasl_file, file_content=content
         )
-        plugin = UpdateModificationDate(fake_context)
+        plugin = CheckLastModification(fake_context)
 
         output = plugin.run()
 
@@ -76,7 +76,7 @@ class TestUpdateModificationDate(PluginTestCase):
         fake_context = self.create_file_plugin_context(
             nasl_file=nasl_file, file_content=content
         )
-        plugin = UpdateModificationDate(fake_context)
+        plugin = CheckLastModification(fake_context)
 
         output = plugin.run()
         error = next(output)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -217,7 +217,7 @@ class TestRunner(unittest.TestCase):
             f"Checking {get_path_from_root(nasl_file, self.root)}",
             output,
         )
-        self.assertIn("Results for plugin update_modification_date", output)
+        self.assertIn("Results for plugin check_last_modification", output)
         # CI terminal formats for 80 chars per line
         self.assertIn(
             "VT does not contain a modification day script tag.",
@@ -256,7 +256,7 @@ class TestRunner(unittest.TestCase):
             "Checking " f"{get_path_from_root(nasl_file, self.root)}",
             output,
         )
-        self.assertIn("Results for plugin update_modification_date", output)
+        self.assertIn("Results for plugin check_last_modification", output)
         self.assertIn(
             "Replaced modification_date 2021-03-24 10:08:26 +0000"
             " (Wed, 24 Mar 2021",

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -31,14 +31,15 @@ from .deprecated_dependency import CheckDeprecatedDependency
 from .deprecated_functions import CheckDeprecatedFunctions
 from .description import CheckDescription
 from .double_end_points import CheckDoubleEndPoints
-from .duplicated_script_tags import CheckDuplicatedScriptTags
 from .duplicate_oid import CheckDuplicateOID
+from .duplicated_script_tags import CheckDuplicatedScriptTags
 from .encoding import CheckEncoding
 from .forking_nasl_functions import CheckForkingNaslFunctions
 from .get_kb_on_services import CheckGetKBOnServices
 from .grammar import CheckGrammar
 from .http_links_in_tags import CheckHttpLinksInTags
 from .illegal_characters import CheckIllegalCharacters
+from .last_modification import CheckLastModification
 from .log_messages import CheckLogMessages
 from .misplaced_compare_in_if import CheckMisplacedCompareInIf
 from .missing_desc_exit import CheckMissingDescExit
@@ -72,13 +73,11 @@ from .spelling import CheckSpelling
 from .tabs import CheckTabs
 from .todo_tbd import CheckTodoTbd
 from .trailing_spaces_tabs import CheckTrailingSpacesTabs
-from .update_modification_date import UpdateModificationDate
 from .using_display import CheckUsingDisplay
 from .valid_oid import CheckValidOID
 from .valid_script_tag_names import CheckValidScriptTagNames
 from .variable_assigned_in_if import CheckVariableAssignedInIf
 from .vt_placement import CheckVTPlacement
-
 
 _PLUGINS = [
     CheckBadwords,
@@ -100,6 +99,7 @@ _PLUGINS = [
     CheckGrammar,
     CheckHttpLinksInTags,
     CheckIllegalCharacters,
+    CheckLastModification,
     CheckLogMessages,
     CheckMisplacedCompareInIf,
     CheckMissingDescExit,
@@ -160,7 +160,7 @@ class Plugins:
 
 class UpdatePlugins(Plugins):
     def __init__(self):
-        super().__init__([UpdateModificationDate], [])
+        super().__init__([CheckLastModification], [])
 
 
 class StandardPlugins(Plugins):

--- a/troubadix/plugins/last_modification.py
+++ b/troubadix/plugins/last_modification.py
@@ -22,17 +22,11 @@ import re
 from typing import Iterator
 
 from troubadix.helper import CURRENT_ENCODING
-from troubadix.plugin import (
-    FilePlugin,
-    LinterError,
-    LinterFix,
-    LinterResult,
-    LinterWarning,
-)
+from troubadix.plugin import FilePlugin, LinterError, LinterFix, LinterResult
 
 
-class UpdateModificationDate(FilePlugin):
-    name = "update_modification_date"
+class CheckLastModification(FilePlugin):
+    name = "check_last_modification"
 
     def run(self) -> Iterator[LinterResult]:
         self.new_file_content = None
@@ -100,13 +94,6 @@ class UpdateModificationDate(FilePlugin):
         self.new_version = correctly_formated_version
         self.old_datetime = old_datetime
         self.new_datetime = correctly_formated_datetime
-
-        yield LinterWarning(
-            f"Outdated last_modification date. Was {old_datetime} "
-            f"and should be {correctly_formated_datetime}",
-            file=self.context.nasl_file,
-            plugin=self.name,
-        )
 
     def fix(self) -> Iterator[LinterResult]:
         if self.new_file_content:


### PR DESCRIPTION
**What**:

Run checking the last modification date and script version as a standard
plugin. This will allow to abandon the `--update-date` argument and
replace it with `--include-tests check_last_modification --fix`.

**Why**:

Remove the hacked `--update-date` mechanism from troubadix at the end.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
