### PR TITLE
Fix: Not working exclusion in double_end_points.py

### DIFF
--- a/troubadix/plugins/double_end_points.py
+++ b/troubadix/plugins/double_end_points.py
@@ -50,7 +50,7 @@ class CheckDoubleEndPoints(FilePlugin):
             for tag_match in tag_matches:
                 if tag_match:
                     doubled_end_points_match = re.search(
-                        r'\.\s*\.(?P<quote>[\'"])\s*\)\s*;',
+                        r'.*\.\s*\.(?P<quote>[\'"])\s*\)\s*;',
                         tag_match.group(0),
                         re.MULTILINE,
                     )


### PR DESCRIPTION
**What**:

The "old" step had a `'.*\.\s*\."\s*\)\s*;'` regex while the new / migrated plugin one had `'\.\s*\.(?P<quote>[\'"])\s*\)\s*;'`. Due to the first missing `.*` the string returned in `doubled_end_points_match.group(0)` only included the following:

```
..");
```

while it actually should contain the following so that the existing exclusion is working:

```
like displaying BLOB-data as image or download-link and much more...");
```
This PR fixes this problem by adding the additional `.*` to make the exclusion working again.

**Why**:

Reduce false positives found in the scope of VTD-1621

**How**:

Run the following before this PR:

```
troubadix --include-tests check_double_end_points -d nasl/common
```

which showed 16 errors:

```
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_double_end_points                                16        0
  -------------------------------------------------------------------
ℹ sum                                                    16        0
```

and after this PR again to see that the error count is dropped as the exclusion of the 11 known false positives is working again:

```
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_double_end_points                                 5        0
  -------------------------------------------------------------------
ℹ sum                                                     5        0
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
