### PR TITLE
Fix: Don't run last_modification.py against .inc files.

### DIFF
--- a/troubadix/plugins/last_modification.py
+++ b/troubadix/plugins/last_modification.py
@@ -29,6 +29,9 @@ class CheckLastModification(FilePlugin):
     name = "check_last_modification"
 
     def run(self) -> Iterator[LinterResult]:
+        if self.context.nasl_file.suffix == ".inc":
+            return
+
         self.new_file_content = None
 
         # update modification date


### PR DESCRIPTION
**What**:

With #304 the plugin got reworked to always run by default. But as `.inc` files don't have such a `last_modification` date this change causes false positives / errors against such `.inc` files.

**Why**:

Fix false positives

**How**:

Run e.g. the following below. Before this PR Troubadix reported a false positive which should be gone afterwards.

```
$ troubadix --files nasl/common/ssl_funcs.inc -v
ℹ Start linting 1 files ... 
ℹ Checking common/ssl_funcs.inc (1/1)
ℹ     Results for plugin check_last_modification
×         VT does not contain a modification day script tag.
ℹ     Results for plugin check_todo_tbd
⚠         VT contains #TODO/TBD/@todo keywords.
⚠         VT contains #TODO/TBD/@todo keywords.
⚠         VT contains #TODO/TBD/@todo keywords.
⚠         VT contains #TODO/TBD/@todo keywords.
ℹ Time elapsed: 0:00:05.399348
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_last_modification                                 1        0
⚠ check_todo_tbd                                          0        4
  -------------------------------------------------------------------
ℹ sum                                                     1        4
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
