### PR TITLE
Update last modification plugins

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -32,6 +32,9 @@ from troubadix.plugins.cvss_format import CheckCVSSFormat
 from troubadix.plugins.duplicate_oid import CheckDuplicateOID
 from troubadix.plugins.missing_desc_exit import CheckMissingDescExit
 from troubadix.plugins.no_solution import CheckNoSolution
+from troubadix.plugins.script_version_and_last_modification_tags import (
+    CheckScriptVersionAndLastModificationTags,
+)
 from troubadix.reporter import Reporter
 from troubadix.runner import Runner, TroubadixException
 
@@ -200,7 +203,7 @@ class TestRunner(unittest.TestCase):
         runner = Runner(
             n_jobs=1,
             reporter=reporter,
-            update_date=True,
+            included_plugins=[CheckScriptVersionAndLastModificationTags.name],
             root=self.root,
         )
 
@@ -215,10 +218,14 @@ class TestRunner(unittest.TestCase):
             f"Checking {get_path_from_root(nasl_file, self.root)}",
             output,
         )
-        self.assertIn("Results for plugin check_last_modification", output)
+        self.assertIn(
+            "Results for plugin "
+            "check_script_version_and_last_modification_tags",
+            output,
+        )
         # CI terminal formats for 80 chars per line
         self.assertIn(
-            "VT does not contain a modification day script tag.",
+            "VT is missing script_version();.",
             output,
         )
 


### PR DESCRIPTION
**What**:

Move responsibility for checking script_version and last_modification tag into the `check_script_version_and_last_modification_tags` plugin.

The `--fix` functionality for `check_script_version_and_last_modification_tags` is slightly different from `check_last_modification`. It only updates the script version and last modification date if the format is wrong. Currently `check_last_modification` updates both unconditionally. This behavior of `check_last_modification` has been kept for the [feed deployment](https://github.com/greenbone/vulnerability-tests/blob/main/.github/workflows/feed-deployment.yml#L257) until there is a replacement.

[DEVOPS-297](https://jira.greenbone.net/browse/DEVOPS-297)

**Why**:

Currently script_version and last_modification are checked twice in `check_script_version_and_last_modification_tags` and `check_last_modification` plugins.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
