### PR TITLE
Fix: Script dependencies allow multiline value

### DIFF
--- a/tests/plugins/test_script_calls_recommended.py
+++ b/tests/plugins/test_script_calls_recommended.py
@@ -64,3 +64,20 @@ class CheckScriptCallsRecommendedTestCase(PluginTestCase):
 
         self.assertEqual(len(results), 2)
         self.assertIsInstance(results[0], LinterWarning)
+
+    def test_dependencies_multiline(self):
+        content = (
+            'script_dependencies("123",\n"456");\n'
+            "script_require_ports();\n"
+            "script_require_udp_ports();\n"
+            "script_require_keys();\n"
+            "script_mandatory_keys();"
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptCallsRecommended(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)

--- a/troubadix/plugins/script_calls_recommended.py
+++ b/troubadix/plugins/script_calls_recommended.py
@@ -79,7 +79,7 @@ class CheckScriptCallsRecommended(FileContentPlugin):
             )
         for call in recommended_single_call:
             if not _get_special_script_tag_pattern(
-                name=call, value=".*"
+                name=call, value="(?s:.)*"
             ).search(file_content):
                 yield LinterWarning(
                     "VT does not contain the following recommended call: "

--- a/troubadix/plugins/script_calls_recommended.py
+++ b/troubadix/plugins/script_calls_recommended.py
@@ -79,7 +79,7 @@ class CheckScriptCallsRecommended(FileContentPlugin):
             )
         for call in recommended_single_call:
             if not _get_special_script_tag_pattern(
-                name=call, value="(?s:.)*"
+                name=call, value=".*", flags=re.DOTALL
             ).search(file_content):
                 yield LinterWarning(
                     "VT does not contain the following recommended call: "

--- a/troubadix/plugins/script_calls_recommended.py
+++ b/troubadix/plugins/script_calls_recommended.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
 from pathlib import Path
 from typing import Iterator
 


### PR DESCRIPTION
**What**:

Fixed `script_calls_recommended.py` so that `script_dependencies` can recognize multiline values.

**Why**:

We had false-positives with the plugin.
Jira: VTD-1626

**How**:

https://stackoverflow.com/questions/33312175/matching-any-character-including-newlines-in-a-python-regex-subexpression-not-g

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
