### PR TITLE
Change: Add a standalone plugin/tool for updating last modification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ version-module-file = "troubadix/__version__.py"
 [tool.poetry.scripts]
 troubadix = 'troubadix.troubadix:main'
 troubadix-changed-oid = 'troubadix.standalone_plugins.changed_oid:main'
+troubadix-last-modification = 'troubadix.standalone_plugins.last_modification:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/standalone_plugins/__init__.py
+++ b/tests/standalone_plugins/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/standalone_plugins/test_last_modification.py
+++ b/tests/standalone_plugins/test_last_modification.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import MagicMock
+
+from tests.plugins import TemporaryDirectory
+from troubadix.standalone_plugins.last_modification import parse_args, update
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    def test_parse_files(self):
+        with TemporaryDirectory() as tempdir:
+            testfile1 = tempdir / "testfile1.nasl"
+            testfile2 = tempdir / "testfile2.nasl"
+
+            testfile1.touch()
+            testfile2.touch()
+
+            args = parse_args(["--file", str(testfile1), str(testfile2)])
+
+            self.assertEqual(args.files[0], testfile1)
+            self.assertEqual(args.files[1], testfile2)
+
+    def test_parse_from_file(self):
+        with TemporaryDirectory() as tempdir:
+            from_file = tempdir / "from_file.txt"
+            testfile1 = tempdir / "testfile1.nasl"
+            testfile2 = tempdir / "testfile2.nasl"
+
+            from_file.write_text(f"{testfile1}\n{testfile2}\n", encoding="utf8")
+
+            args = parse_args(["--from-file", str(from_file)])
+
+            self.assertEqual(args.from_file, from_file)
+
+
+class UpdateTestCase(unittest.TestCase):
+    def test_update(self):
+        terminal = MagicMock()
+        with TemporaryDirectory() as tempdir:
+            content = (
+                'script_version("2021-07-19T12:32:02+0000");\n'
+                'script_tag(name: "last_modification", value: "2021-07-19 '
+                '12:32:02 +0000 (Mon, 19 Jul 2021)");\n'
+            )
+            testfile1 = tempdir / "testfile1.nasl"
+            testfile1.write_text(content, encoding="utf8")
+
+            update(testfile1, terminal)
+
+            new_content = testfile1.read_text(encoding="utf8")
+
+            self.assertNotEqual(content, new_content)
+
+    def test_update_invalid_date(self):
+        terminal = MagicMock()
+        with TemporaryDirectory() as tempdir:
+            content = (
+                'script_version("foo");\n'
+                'script_tag(name: "last_modification", value: "bar");\n'
+            )
+            testfile1 = tempdir / "testfile1.nasl"
+            testfile1.write_text(content, encoding="utf8")
+
+            update(testfile1, terminal)
+
+            new_content = testfile1.read_text(encoding="utf8")
+
+            self.assertNotEqual(content, new_content)
+
+    def test_no_update_missing_script_version(self):
+        terminal = MagicMock()
+        with TemporaryDirectory() as tempdir:
+            content = 'script_tag(name: "last_modification", value: "bar");\n'
+            testfile1 = tempdir / "testfile1.nasl"
+            testfile1.write_text(content, encoding="utf8")
+
+            update(testfile1, terminal)
+
+            new_content = testfile1.read_text(encoding="utf8")
+
+            self.assertEqual(content, new_content)
+
+    def test_no_update_missing_last_modification_tag(self):
+        terminal = MagicMock()
+        with TemporaryDirectory() as tempdir:
+            content = 'script_version("2021-07-19T12:32:02+0000");\n'
+            testfile1 = tempdir / "testfile1.nasl"
+            testfile1.write_text(content, encoding="utf8")
+
+            update(testfile1, terminal)
+
+            new_content = testfile1.read_text(encoding="utf8")
+
+            self.assertEqual(content, new_content)

--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -21,6 +21,20 @@ from typing import Dict
 
 from troubadix.helper.helper import SCRIPT_CATEGORIES
 
+# regexp pattern for getting any value of
+# script_tag(name:"last_modification", value:"<value>");
+LAST_MODIFICATION_ANY_VALUE_PATTERN = (
+    r'script_tag\(\s*name\s*:\s*(?P<quote>[\'"])(last_modification)'
+    r'(?P=quote)\s*,\s*value\s*:\s*(?P<quote2>[\'"])?'
+    r"(?P<value>.*)(?P=quote2)?\s*\)\s*;"
+)
+
+# regexp pattern for getting any value of
+# script_version("<value>");
+SCRIPT_VERSION_ANY_VALUE_PATTERN = (
+    r'script_version\(\s*(?P<quote>[\'"])(?P<value>.*)(?P=quote)\s*\);'
+)
+
 # regex patterns for script tags
 _TAG_PATTERN = (
     r'script_tag\(\s*name\s*:\s*(?P<quote>[\'"])(?P<name>{name})(?P=quote)\s*,'

--- a/troubadix/plugins/script_version_and_last_modification_tags.py
+++ b/troubadix/plugins/script_version_and_last_modification_tags.py
@@ -22,6 +22,8 @@ from typing import Iterator
 
 from troubadix.helper import CURRENT_ENCODING
 from troubadix.helper.patterns import (
+    LAST_MODIFICATION_ANY_VALUE_PATTERN,
+    SCRIPT_VERSION_ANY_VALUE_PATTERN,
     ScriptTag,
     SpecialScriptTag,
     get_script_tag_pattern,
@@ -61,12 +63,8 @@ class CheckScriptVersionAndLastModificationTags(FileContentPlugin):
         if nasl_file.suffix == ".inc":
             return
 
-        script_version_any_pattern = (
-            r'script_version\(\s*(?P<quote>[\'"])(?P<value>.*)(?P=quote)\s*\);'
-        )
-
         match_script_version_any = re.search(
-            pattern=script_version_any_pattern,
+            pattern=SCRIPT_VERSION_ANY_VALUE_PATTERN,
             string=file_content,
         )
         if not match_script_version_any:
@@ -102,14 +100,8 @@ class CheckScriptVersionAndLastModificationTags(FileContentPlugin):
                     plugin=self.name,
                 )
 
-        last_modification_any_value_pattern = (
-            r'script_tag\(\s*name\s*:\s*(?P<quote>[\'"])(last_modification)'
-            r'(?P=quote)\s*,\s*value\s*:\s*(?P<quote2>[\'"])?'
-            r"(?P<value>.*)(?P=quote2)?\s*\)\s*;"
-        )
-
         match_last_modification_any_value = re.search(
-            pattern=last_modification_any_value_pattern,
+            pattern=LAST_MODIFICATION_ANY_VALUE_PATTERN,
             string=file_content,
         )
 

--- a/troubadix/standalone_plugins/last_modification.py
+++ b/troubadix/standalone_plugins/last_modification.py
@@ -28,6 +28,10 @@ from pontos.terminal import Terminal
 from pontos.terminal.terminal import ConsoleTerminal
 
 from troubadix.helper import CURRENT_ENCODING
+from troubadix.helper.patterns import (
+    LAST_MODIFICATION_ANY_VALUE_PATTERN,
+    SCRIPT_VERSION_ANY_VALUE_PATTERN,
+)
 from troubadix.troubadix import from_file
 
 
@@ -45,14 +49,9 @@ def update(nasl_file: Path, terminal: Terminal):
 
     # update modification date
     tag_template = 'script_tag(name:"last_modification", value:"{date}");'
-    last_modification_any_value_pattern = (
-        r'script_tag\(\s*name\s*:\s*(?P<quote>[\'"])(last_modification)'
-        r'(?P=quote)\s*,\s*value\s*:\s*(?P<quote2>[\'"])?'
-        r"(?P<value>.*)(?P=quote2)?\s*\)\s*;"
-    )
 
     match_last_modification_any_value = re.search(
-        pattern=last_modification_any_value_pattern,
+        pattern=LAST_MODIFICATION_ANY_VALUE_PATTERN,
         string=file_content,
     )
 
@@ -75,12 +74,9 @@ def update(nasl_file: Path, terminal: Terminal):
 
     # update script version
     script_version_template = 'script_version("{date}");'
-    script_version_any_pattern = (
-        r'script_version\(\s*(?P<quote>[\'"])(?P<value>.*)(?P=quote)\s*\);'
-    )
 
     match_script_version = re.search(
-        pattern=script_version_any_pattern,
+        pattern=SCRIPT_VERSION_ANY_VALUE_PATTERN,
         string=file_content,
     )
     if not match_script_version:

--- a/troubadix/standalone_plugins/last_modification.py
+++ b/troubadix/standalone_plugins/last_modification.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" updating the modification time in VTs that have been touched/edited """
+
+import datetime
+import re
+import sys
+from argparse import ArgumentParser, ArgumentTypeError, Namespace
+from pathlib import Path
+from typing import Iterable
+
+from pontos.terminal import Terminal
+from pontos.terminal.terminal import ConsoleTerminal
+
+from troubadix.helper import CURRENT_ENCODING
+from troubadix.troubadix import from_file
+
+
+def existing_file_type(string: str) -> Path:
+    file_path = Path(string)
+    if not file_path.exists():
+        raise ArgumentTypeError(f'File "{string}" does not exist.')
+    if not file_path.is_file():
+        raise ArgumentTypeError(f'"{string}" is not a file.')
+    return file_path
+
+
+def update(nasl_file: Path, terminal: Terminal):
+    file_content = nasl_file.read_text(encoding=CURRENT_ENCODING)
+
+    # update modification date
+    tag_template = 'script_tag(name:"last_modification", value:"{date}");'
+    last_modification_any_value_pattern = (
+        r'script_tag\(\s*name\s*:\s*(?P<quote>[\'"])(last_modification)'
+        r'(?P=quote)\s*,\s*value\s*:\s*(?P<quote2>[\'"])?'
+        r"(?P<value>.*)(?P=quote2)?\s*\)\s*;"
+    )
+
+    match_last_modification_any_value = re.search(
+        pattern=last_modification_any_value_pattern,
+        string=file_content,
+    )
+
+    if not match_last_modification_any_value:
+        terminal.warning(
+            f'Ignoring "{nasl_file}" because it is missing a '
+            "last_modification tag."
+        )
+        return
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    # get that date formatted correctly:
+    # "2021-03-24 10:08:26 +0000 (Wed, 24 Mar 2021)"
+    correctly_formatted_datetime = f"{now:%Y-%m-%d %H:%M:%S %z (%a, %d %b %Y)}"
+
+    file_content = file_content.replace(
+        match_last_modification_any_value.group(0),
+        tag_template.format(date=correctly_formatted_datetime),
+    )
+
+    # update script version
+    script_version_template = 'script_version("{date}");'
+    script_version_any_pattern = (
+        r'script_version\(\s*(?P<quote>[\'"])(?P<value>.*)(?P=quote)\s*\);'
+    )
+
+    match_script_version = re.search(
+        pattern=script_version_any_pattern,
+        string=file_content,
+    )
+    if not match_script_version:
+        terminal.warning(
+            f'Ignoring "{nasl_file}" because it is missing a ' "script_version."
+        )
+        return
+
+    # get that date formatted correctly:
+    # "2021-03-24T10:08:26+0000"
+    correctly_formatted_version = f"{now:%Y-%m-%dT%H:%M:%S%z}"
+
+    new_file_content = file_content.replace(
+        match_script_version.group(0),
+        script_version_template.format(date=correctly_formatted_version),
+    )
+
+    nasl_file.write_text(new_file_content, encoding=CURRENT_ENCODING)
+
+
+def parse_args() -> Namespace:
+    parser = ArgumentParser(
+        description="Update script_version and last_modification tags"
+    )
+    what_group = parser.add_mutually_exclusive_group(required=True)
+    what_group.add_argument(
+        "--files",
+        nargs="+",
+        type=existing_file_type,
+        help="List of files that should be updated",
+    )
+    what_group.add_argument(
+        "--from-file",
+        type=existing_file_type,
+        help=(
+            "Pass a file that contains a List of files "
+            "containing paths to files, that should be "
+            "updated. Files should be separated by newline."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    parsed_args = parse_args()
+    terminal = ConsoleTerminal()
+
+    if parsed_args.from_file:
+        files = from_file(include_file=parsed_args.from_file, term=terminal)
+    elif parsed_args.files:
+        files: Iterable[Path] = parsed_args.files
+    else:
+        # will not happen
+        sys.exit(1)
+
+    for nasl_file in files:
+        if nasl_file.suffix != ".nasl":
+            terminal.warning(f'Skipping "{nasl_file}". Not a nasl file.')
+            continue
+
+        terminal.info(f'Updating "{nasl_file}"')
+        update(nasl_file, terminal)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/troubadix/standalone_plugins/last_modification.py
+++ b/troubadix/standalone_plugins/last_modification.py
@@ -22,7 +22,7 @@ import re
 import sys
 from argparse import ArgumentParser, ArgumentTypeError, Namespace
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
 from pontos.terminal import Terminal
 from pontos.terminal.terminal import ConsoleTerminal
@@ -97,7 +97,7 @@ def update(nasl_file: Path, terminal: Terminal):
     nasl_file.write_text(new_file_content, encoding=CURRENT_ENCODING)
 
 
-def parse_args() -> Namespace:
+def parse_args(args: Sequence[str] = None) -> Namespace:
     parser = ArgumentParser(
         description="Update script_version and last_modification tags"
     )
@@ -117,7 +117,7 @@ def parse_args() -> Namespace:
             "updated. Files should be separated by newline."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def main() -> int:


### PR DESCRIPTION
**What**:

This new console line interface tool allows to update the script_version
and last_modification tag to the current date and time for passed nasl
scripts. It will replace the deprecated `check_last_modification`
plugin.

**Why**:

Allow to unconditionally update `last_modification` date for nasl scripts.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
