### PR TITLE
Added nthumann and mbrinkhoff to codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # default reviewers
 *                         @greenbone/devops
 *                         @n-thumann @mbrinkhoff
+
 # exceptions
 /troubadix/codespell/*   @greenbone/vulnerability-test-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # default reviewers
 *                         @greenbone/devops
-
+*                         @n-thumann @mbrinkhoff
 # exceptions
 /troubadix/codespell/*   @greenbone/vulnerability-test-maintainers


### PR DESCRIPTION
**What**:

Adds @n-thumann and @mbrinkhoff to the codeowners file to enable normal reviews.

**Why**:

Part of the handover process

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] Conventional commit message N/A
- [ ] Documentation N/A
