### PR TITLE
Add exclusion to http_links_in_tags plugin

### DIFF
--- a/tests/plugins/test_http_links_in_tags.py
+++ b/tests/plugins/test_http_links_in_tags.py
@@ -149,6 +149,7 @@ class CheckHttpLinksInTagsTestCase(PluginTestCase):
             "37.  (www.isg.rhul.ac.uk) for discovering this flaw and Adam Langley and",
             "38. Sorry about having to reissue this one -- I pulled it from ftp.gnu.org not",
             "39. http://internal-host$1 is still insecure",
+            "40. from online sources (ftp://, http:// etc.).",
         ]
 
         for testcase in testcases:

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -164,6 +164,7 @@ class CheckHttpLinksInTags(FilePlugin):
             "'http://'",
             "'https://'",
             "http://internal-host$1 is still insecure",
+            "http:// ",
         ]
 
         return any(


### PR DESCRIPTION
**What**:
This PR adds a exclude to http_links_in_tags plugin.

**Why**:
To make the QA of https://github.com/greenbone/vulnerability-tests/pull/78 happy.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
