### PR TITLE
Add: Exclusion to http_links_in_tags plugin

### DIFF
--- a/tests/plugins/test_http_links_in_tags.py
+++ b/tests/plugins/test_http_links_in_tags.py
@@ -150,6 +150,7 @@ class CheckHttpLinksInTagsTestCase(PluginTestCase):
             "38. Sorry about having to reissue this one -- I pulled it from ftp.gnu.org not",
             "39. http://internal-host$1 is still insecure",
             "40. from online sources (ftp://, http:// etc.).",
+            "41. this and https:// and that.",
         ]
 
         for testcase in testcases:

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -165,6 +165,7 @@ class CheckHttpLinksInTags(FilePlugin):
             "'https://'",
             "http://internal-host$1 is still insecure",
             "http:// ",
+            "https:// ",
         ]
 
         return any(


### PR DESCRIPTION
**What**:

Similar to #322 but for the `https://` scheme.

**Why**:

Sooner or later there will be a similar false positive like solved in #322 

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
