### PR TITLE
Add: Additional grammar regex and related tests for grammar.py

### DIFF
--- a/tests/plugins/test_grammar.py
+++ b/tests/plugins/test_grammar.py
@@ -98,3 +98,57 @@ class CheckNewlinesTestCase(PluginTestCase):
             "# refer the Reference",
             results[1].message,
         )
+
+    def test_grammar3(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            'script_tag(name:"summary", value:"Adobe Digital Edition is prone '
+            'a to denial of service (DoS) vulnerability.");\n'
+        )
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckGrammar(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "VT/Include has the following grammar problem: "
+            'script_tag(name:"summary", value:"Adobe Digital Edition is prone '
+            'a to denial of service (DoS) vulnerability.");',
+            results[0].message,
+        )
+
+    def test_grammar4(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            'script_tag(name:"summary", value:"Splunk Enterprise is prone an '
+            'open redirect vulnerability.");\n'
+        )
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckGrammar(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "VT/Include has the following grammar problem: "
+            'script_tag(name:"summary", value:"Splunk Enterprise is prone an '
+            'open redirect vulnerability.");',
+            results[0].message,
+        )

--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -62,6 +62,10 @@ def get_grammer_pattern() -> re.Pattern:
         r"|file\s+inclusion)|SQL\s+injection|security|(local )?privilege"
         r"[\s-]+(escalation|elevation)|(authentication|security|access)"
         r"\s+bypass|(buffer|heap)\s+overflow)\s+vulnerability|"
+        # e.g.:
+        # "is prone a to denial of service (DoS) vulnerability"
+        # "is prone an information disclosure vulnerability"
+        r"\s+(is|are)\s+(prone|vulnerable|affected)\s+an?\s+|"
         # e.g. "is prone to a security bypass vulnerabilities"
         r"is\s+prone\s+to\s+an?\s+[^\s]+\s+([^\s]+\s+)?vulnerabilities" r").*",
         re.IGNORECASE,


### PR DESCRIPTION
**What**:

Extend the regex to catch additional common grammar problems / mistakes.

**Why**:

N/A

**How**:

- Run `troubadix -d nasl/common --include-tests check_grammar -v` (Should find 17 occurrences on a VT repository before greenbone/vulnerability-tests#347)
- :robot:

**Checklist**:

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
