### PR TITLE
Change: Update spelling exclusion for LSCs in spelling.py

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -175,7 +175,7 @@ class CheckSpelling(FilePlugin):
                 # "ALSA: hda" or a codec called "Conexant". There are too
                 # many hits to maintain them in codespell.exclude so exclude
                 # them for now here.
-                if re.search(r"gb_(sles|(open)?suse)_.+\.nasl", line):
+                if re.search(r"(gb_(sles|(open)?suse)_|mgasa-).+\.nasl", line):
                     if re.search(
                         r"(hda|conexant)\s+==>\s+(had|connexant)",
                         line,


### PR DESCRIPTION
**What**:

This is now also happening in MGASA/Mageia related advisories like seen in greenbone/vulnerability-tests#385:

```
ℹ Checking 21.04/2022/mageia/mgasa-2022-0263.nasl (6/7)
ℹ     Results for plugin check_spelling
×         /path/to/2022/mageia/mgasa-2022-0263.nasl:93: conexant ==> connexant
```

**Why**:

Exclude false positives

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
