### PR TITLE
Switch spelling plugin to files plugin

### DIFF
--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Iterable
 from unittest.mock import MagicMock
 
-from troubadix.plugin import FilePluginContext
+from troubadix.plugin import FilePluginContext, FilesPluginContext
 
 
 class TemporaryDirectory:
@@ -62,5 +62,17 @@ class PluginTestCase(unittest.TestCase):
         fake_context.nasl_file = nasl_file
         fake_context.file_content = file_content
         fake_context.lines = lines
+        fake_context.root = root
+        return fake_context
+
+    def create_files_plugin_context(
+        self,
+        *,
+        nasl_files: Iterable[Path] = None,
+        root: Path = None,
+    ) -> FilesPluginContext:
+        """Create a FilePluginContext mock"""
+        fake_context = MagicMock()
+        fake_context.nasl_files = nasl_files
         fake_context.root = root
         return fake_context

--- a/tests/plugins/test_spelling.py
+++ b/tests/plugins/test_spelling.py
@@ -25,10 +25,7 @@ from . import PluginTestCase
 class CheckSpellingTestCase(PluginTestCase):
     def test_ok(self):
         nasl_file = Path(__file__).parent / "test.nasl"
-        content = "# this is not used, it use the nasl_file instead\n"
-        fake_context = self.create_file_plugin_context(
-            nasl_file=nasl_file, file_content=content
-        )
+        fake_context = self.create_files_plugin_context(nasl_files=[nasl_file])
         plugin = CheckSpelling(fake_context)
 
         results = list(plugin.run())
@@ -37,15 +34,12 @@ class CheckSpellingTestCase(PluginTestCase):
 
     def test_nok(self):
         nasl_file = Path(__file__).parent / "test_files" / "fail_spelling.nasl"
-        content = "# this is not used, it use the nasl_file instead\n"
-        fake_context = self.create_file_plugin_context(
-            nasl_file=nasl_file, file_content=content
-        )
+        fake_context = self.create_files_plugin_context(nasl_files=[nasl_file])
         plugin = CheckSpelling(fake_context)
 
         results = list(plugin.run())
 
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 4)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             f"{nasl_file}:1: soltuion ==> solution\n"
@@ -59,17 +53,14 @@ class CheckSpellingTestCase(PluginTestCase):
         codespell_additions.write_text("", encoding="utf-8")
 
         nasl_file = Path(__file__).parent / "test_files" / "fail_spelling.nasl"
-        content = "# this is not used, it use the nasl_file instead\n"
-        fake_context = self.create_file_plugin_context(
-            nasl_file=nasl_file, file_content=content
-        )
+        fake_context = self.create_files_plugin_context(nasl_files=[nasl_file])
         plugin = CheckSpelling(fake_context)
 
         results = list(plugin.run())
 
         codespell_additions.unlink()
 
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             f"{nasl_file}:2: upated ==> updated\n",

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -57,8 +57,8 @@ from .script_category import CheckScriptCategory
 from .script_copyright import CheckScriptCopyright
 from .script_family import CheckScriptFamily
 from .script_tag_form import CheckScriptTagForm
-from .script_tags_mandatory import CheckScriptTagsMandatory
 from .script_tag_whitespaces import CheckScriptTagWhitespaces
+from .script_tags_mandatory import CheckScriptTagsMandatory
 from .script_version_and_last_modification_tags import (
     CheckScriptVersionAndLastModificationTags,
 )
@@ -124,7 +124,6 @@ _FILE_PLUGINS = [
     CheckSecurityMessages,
     CheckSolutionText,
     CheckSolutionType,
-    CheckSpelling,
     CheckTabs,
     CheckTodoTbd,
     CheckTrailingSpacesTabs,
@@ -140,6 +139,7 @@ _FILE_PLUGINS = [
 _FILES_PLUGINS = [
     CheckDuplicateOID,
     CheckNoSolution,
+    CheckSpelling,
 ]
 
 

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -55,13 +55,8 @@ class CheckSpelling(FilesPlugin):
         else:
             codespell_ignore = f"{codespell_config_path}/codespell.ignore"
 
-        # Run codespell as internal process
         batch_size = 10_000
         for i in range(0, len(self.context.nasl_files), batch_size):
-            # files_parameter = [
-            #     str(nasl_file)
-            #     for nasl_file in self.context.nasl_files[i : i + batch_size]
-            # ]
 
             files_parameters = [
                 str(nasl_file)

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -33,16 +33,12 @@ class CheckSpelling(FilesPlugin):
     name = "check_spelling"
 
     def run(self) -> Iterator[LinterResult]:
-        """'codespell' is required to execute this step!
-        This script opens a shell in a subprocess and executes 'codespell' to
-        check the VT for spelling mistakes. An error will be thrown if
-        'codespell' is not installed or corrections could be found via
-        'codespell'.
+        """This script checks, via the codespell library, wether
+        the provided nasl files contain spelling errors.
+        Certain errors are ignored based on listed exceptions
 
-        Args:
-            nasl_file: The VT that is going to be checked
-            _file_content: The content of the VT
-
+        Yields:
+            Iterator[LinterResult]: The detected spelling errors
         """
 
         # Overwrite with local repository files if exist

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -63,20 +63,18 @@ class CheckSpelling(FilesPlugin):
             #     for nasl_file in self.context.nasl_files[i : i + batch_size]
             # ]
 
-            files_parameters = tuple(
-                [
-                    str(nasl_file)
-                    for nasl_file in self.context.nasl_files[i : i + batch_size]
-                ]
-            )
-            codespell_arguments = (
+            files_parameters = [
+                str(nasl_file)
+                for nasl_file in self.context.nasl_files[i : i + batch_size]
+            ]
+            codespell_arguments = [
                 "--hard-encoding-detection",
                 "--dictionary=-",
                 f"--dictionary={codespell_additions}",
                 f"--exclude-file={codespell_exclude}",
                 f"--ignore-words={codespell_ignore}",
                 "--disable-colors",
-            ) + files_parameters
+            ] + files_parameters
 
             with redirect_stdout(io.StringIO()) as codespell:
                 codespell_main(*codespell_arguments)

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -15,24 +15,21 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
 import io
+import re
 from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Iterator
 
 from codespell_lib import main as codespell_main
-from troubadix.plugin import (
-    FilePlugin,
-    LinterError,
-    LinterResult,
-)
+
+from troubadix.plugin import FilesPlugin, LinterError, LinterResult
 
 plugin_path = Path(__file__).parent.resolve()
 codespell_config_path = (plugin_path.parent / "codespell").resolve()
 
 
-class CheckSpelling(FilePlugin):
+class CheckSpelling(FilesPlugin):
     name = "check_spelling"
 
     def run(self) -> Iterator[LinterResult]:
@@ -63,177 +60,193 @@ class CheckSpelling(FilePlugin):
             codespell_ignore = f"{codespell_config_path}/codespell.ignore"
 
         # Run codespell as internal process
-        with redirect_stdout(io.StringIO()) as codespell:
-            codespell_main(
-                *(
-                    "--hard-encoding-detection",
-                    "--dictionary=-",
-                    f"--dictionary={codespell_additions}",
-                    f"--exclude-file={codespell_exclude}",
-                    f"--ignore-words={codespell_ignore}",
-                    "--disable-colors",
-                    f"{str(self.context.nasl_file)}",
-                )
+        batch_size = 10_000
+        for i in range(0, len(self.context.nasl_files), batch_size):
+            # files_parameter = [
+            #     str(nasl_file)
+            #     for nasl_file in self.context.nasl_files[i : i + batch_size]
+            # ]
+
+            files_parameters = tuple(
+                [
+                    str(nasl_file)
+                    for nasl_file in self.context.nasl_files[i : i + batch_size]
+                ]
             )
+            codespell_arguments = (
+                "--hard-encoding-detection",
+                "--dictionary=-",
+                f"--dictionary={codespell_additions}",
+                f"--exclude-file={codespell_exclude}",
+                f"--ignore-words={codespell_ignore}",
+                "--disable-colors",
+            ) + files_parameters
 
-        codespell = codespell.getvalue()
-        if "Traceback (most recent call last):" not in codespell:
-            _codespell = codespell.splitlines()
-            codespell = ""
-            for line in _codespell:
+            with redirect_stdout(io.StringIO()) as codespell:
+                codespell_main(*codespell_arguments)
 
-                # From /Policy which is just a huge blob of text and too large
-                # for codespell.exclude:
-                if "policy_file_checksums_win.nasl" in line:
-                    if re.search(r"nD\s+==>\s+and, 2nd", line) or re.search(
-                        r"oD\s+==>\s+of", line
+            codespell = codespell.getvalue()
+            if "Traceback (most recent call last):" not in codespell:
+                _codespell = codespell.splitlines()
+                codespell = ""
+                for line in _codespell:
+
+                    # From /Policy which is just a huge blob of text
+                    # and too large for codespell.exclude:
+                    if "policy_file_checksums_win.nasl" in line:
+                        if re.search(r"nD\s+==>\s+and, 2nd", line) or re.search(
+                            r"oD\s+==>\s+of", line
+                        ):
+                            continue
+
+                    # Same for a few other files:
+                    if "smtp_AV_42zip_DoS.nasl" in line and re.search(
+                        r"BA\s+==>\s+BY, BE", line
                     ):
                         continue
 
-                # Same for a few other files:
-                if "smtp_AV_42zip_DoS.nasl" in line and re.search(
-                    r"BA\s+==>\s+BY, BE", line
-                ):
-                    continue
-
-                if "bad_ssh_host_keys.inc" in line and re.search(
-                    r"ba\s+==>\s+by, be", line
-                ):
-                    continue
-
-                if "wmi_misc.inc" in line:
-                    if re.search(r"BA\s+==>\s+BY, BE", line) or re.search(
-                        r"OD\s+==>\s+OF", line
+                    if "bad_ssh_host_keys.inc" in line and re.search(
+                        r"ba\s+==>\s+by, be", line
                     ):
                         continue
 
-                if (
-                    "ssl_funcs.inc" in line
-                    or "gb_ssl_tls_cert_details.nasl" in line
-                ):
-                    if re.search(r"fpr\s+==>\s+for, far, fps", line):
-                        continue
+                    if "wmi_misc.inc" in line:
+                        if re.search(r"BA\s+==>\s+BY, BE", line) or re.search(
+                            r"OD\s+==>\s+OF", line
+                        ):
+                            continue
 
-                # Name of a Huawei product
-                if (
-                    "gb_huawei" in line
-                    or "telnetserver_detect_type_nd_version.nasl" in line
-                ):
-                    if re.search(
-                        r"eSpace\s+==>\s+escape", line, flags=re.IGNORECASE
-                    ):
-                        continue
-
-                # "ure" is a Debian package, again too many hits for
-                # codespell.exclude.
-                if re.search(
-                    r"(deb_(dla_)?[0-9]+(_[" r"0-9]+)?|gb_ubuntu_.+)\.nasl",
-                    line,
-                ):
-                    if re.search(r"ure\s+==>\s+sure", line):
-                        continue
-
-                # gsf/PCIDSS VTs are currently using some german text parts
-                # nb: codespell seems to have some issues with german umlauts
-                # in the codespell.exclude so a few of these were also excluded
-                # here instead of directly via codespell.exclude.
-                if (
-                    "PCIDSS/" in line
-                    or "GSHB/" in line
-                    or "attic/PCIDSS_" in line
-                    or "ITG_Kompendium/" in line
-                ):
-                    if re.search(
-                        r"(sie|ist|oder|prozess|manuell|unter|funktion|"
-                        r"alle|als|tage|lokale|uptodate|paket|titel|ba|"
-                        r"ordner|modul|interaktive|programm|explizit|"
-                        r"normale|applikation|attributen|lokal|signatur|"
-                        r"modell|klick|generell)\s+==>\s+",
-                        line,
-                        flags=re.IGNORECASE,
-                    ):
-                        continue
-
-                # False positives in the gsf/PCIDSS and GSHB/ VTs:
-                # string('\nIn the file sent\nin milliseconds
-                # There are too many hits to maintain them in codespell.exclude
-                # so exclude them for now here.
-                if (
-                    "PCIDSS/" in line
-                    or "GSHB/" in line
-                    or "attic/PCIDSS_" in line
-                ):
-                    if re.search(r"n[iI]n\s+==>\s+inn", line):
-                        continue
-
-                # False positive in this VT in German example responses.
-                if "gb_exchange_server_CVE-2021-26855_active.nasl" in line:
-                    if re.search(r"ist\s+==>\s+is", line):
-                        continue
-
-                # Mostly a false positive in LSCs because of things like
-                # "ALSA: hda" or a codec called "Conexant". There are too
-                # many hits to maintain them in codespell.exclude so exclude
-                # them for now here.
-                if re.search(
-                    r"gb_(sles|(open)?suse|ubuntu_USN)_.+\.nasl", line
-                ):
-                    if re.search(
-                        r"(hda|conexant)\s+==>\s+(had|connexant)",
-                        line,
-                        flags=re.IGNORECASE,
-                    ):
-                        continue
-
-                # Jodie Chancel is a security researcher who is mentioned many
-                # times in Mozilla advisories
-                if re.search(
-                    r"gb_mozilla_firefox_mfsa_\d{4}-\d{2,4}_lin\.nasl", line
-                ) and re.search(r"Chancel\s+==>\s+Cancel", line):
-                    continue
-
-                # Look like correct as this is also in dictionary_rare.txt
-                if "deb_dla_2896.nasl" in line and re.search(
-                    r"dependant\s+==>\s+dependent", line
-                ):
-                    continue
-
-                # Similar to the one above for e.g. SLES. Also exclude "tre",
-                # because it's a package name.
-                if re.search(r"mgasa-\d{4}-\d{4}.nasl", line) and re.search(
-                    r"(hda|tre|conexant)\s+==>\s+(had|tree|connexant)",
-                    line,
-                    flags=re.IGNORECASE,
-                ):
-                    continue
-
-                # Similar to the corrections above, with some additional
-                # exclusions like e.g. names
-                if re.search(r"ELSA-\d{4}-\d{4,5}\.nasl", line):
                     if (
-                        re.search(r"Stange\s+==>\s+Strange", line)
-                        or re.search(r"chang\s+==>\s+change, charge", line)
-                        or re.search(
-                            r"IST\s+==>\s+IS, IT, ITS, IT'S, SIT, LIST", line
-                        )
-                        or re.search(r"hda\s+==>\s+had", line)
-                        or re.search(r"Readded\s+==>\s+Read", line)
-                        or re.search(r"ACI\s+==>\s+ACPI", line, re.IGNORECASE)
-                        or re.search(r"UE\s+==>\s+USE, DUE", line)
+                        "ssl_funcs.inc" in line
+                        or "gb_ssl_tls_cert_details.nasl" in line
+                    ):
+                        if re.search(r"fpr\s+==>\s+for, far, fps", line):
+                            continue
+
+                    # Name of a Huawei product
+                    if (
+                        "gb_huawei" in line
+                        or "telnetserver_detect_type_nd_version.nasl" in line
+                    ):
+                        if re.search(
+                            r"eSpace\s+==>\s+escape", line, flags=re.IGNORECASE
+                        ):
+                            continue
+
+                    # "ure" is a Debian package, again too many hits for
+                    # codespell.exclude.
+                    if re.search(
+                        r"(deb_(dla_)?[0-9]+(_[" r"0-9]+)?|gb_ubuntu_.+)\.nasl",
+                        line,
+                    ):
+                        if re.search(r"ure\s+==>\s+sure", line):
+                            continue
+
+                    # gsf/PCIDSS VTs are currently using some german text parts
+                    # nb: codespell seems to have some issues with
+                    # german umlauts in the codespell.exclude so a few of these
+                    # were also excluded here instead of directly
+                    # via codespell.exclude.
+                    if (
+                        "PCIDSS/" in line
+                        or "GSHB/" in line
+                        or "attic/PCIDSS_" in line
+                        or "ITG_Kompendium/" in line
+                    ):
+                        if re.search(
+                            r"(sie|ist|oder|prozess|manuell|unter|funktion|"
+                            r"alle|als|tage|lokale|uptodate|paket|titel|ba|"
+                            r"ordner|modul|interaktive|programm|explizit|"
+                            r"normale|applikation|attributen|lokal|signatur|"
+                            r"modell|klick|generell)\s+==>\s+",
+                            line,
+                            flags=re.IGNORECASE,
+                        ):
+                            continue
+
+                    # False positives in the gsf/PCIDSS and GSHB/ VTs:
+                    # string('\nIn the file sent\nin milliseconds
+                    # There are too many hits to maintain
+                    # them in codespell.exclude so exclude them for now here.
+                    if (
+                        "PCIDSS/" in line
+                        or "GSHB/" in line
+                        or "attic/PCIDSS_" in line
+                    ):
+                        if re.search(r"n[iI]n\s+==>\s+inn", line):
+                            continue
+
+                    # False positive in this VT in German example responses.
+                    if "gb_exchange_server_CVE-2021-26855_active.nasl" in line:
+                        if re.search(r"ist\s+==>\s+is", line):
+                            continue
+
+                    # Mostly a false positive in LSCs because of things like
+                    # "ALSA: hda" or a codec called "Conexant". There are too
+                    # many hits to maintain them in codespell.exclude so exclude
+                    # them for now here.
+                    if re.search(
+                        r"gb_(sles|(open)?suse|ubuntu_USN)_.+\.nasl", line
+                    ):
+                        if re.search(
+                            r"(hda|conexant)\s+==>\s+(had|connexant)",
+                            line,
+                            flags=re.IGNORECASE,
+                        ):
+                            continue
+
+                    # Jodie Chancel is a security researcher who is mentioned
+                    # many times in Mozilla advisories
+                    if re.search(
+                        r"gb_mozilla_firefox_mfsa_\d{4}-\d{2,4}_lin\.nasl", line
+                    ) and re.search(r"Chancel\s+==>\s+Cancel", line):
+                        continue
+
+                    # Look like correct as this is also in dictionary_rare.txt
+                    if "deb_dla_2896.nasl" in line and re.search(
+                        r"dependant\s+==>\s+dependent", line
                     ):
                         continue
 
-                codespell += line + "\n"
+                    # Similar to the one above for e.g. SLES.
+                    # Also exclude "tre", because it's a package name.
+                    if re.search(r"mgasa-\d{4}-\d{4}.nasl", line) and re.search(
+                        r"(hda|tre|conexant)\s+==>\s+(had|tree|connexant)",
+                        line,
+                        flags=re.IGNORECASE,
+                    ):
+                        continue
 
-        if "==>" in codespell:
-            yield LinterError(
-                codespell,
-                file=self.context.nasl_file,
-                plugin=self.name,
-            )
-        elif "Traceback (most recent call last):" in codespell:
-            yield LinterError(
-                codespell,
-                file=self.context.nasl_file,
-                plugin=self.name,
-            )
+                    # Similar to the corrections above, with some additional
+                    # exclusions like e.g. names
+                    if re.search(r"ELSA-\d{4}-\d{4,5}\.nasl", line):
+                        if (
+                            re.search(r"Stange\s+==>\s+Strange", line)
+                            or re.search(r"chang\s+==>\s+change, charge", line)
+                            or re.search(
+                                r"IST\s+==>\s+IS, IT, ITS, IT'S, SIT, LIST",
+                                line,
+                            )
+                            or re.search(r"hda\s+==>\s+had", line)
+                            or re.search(r"Readded\s+==>\s+Read", line)
+                            or re.search(
+                                r"ACI\s+==>\s+ACPI", line, re.IGNORECASE
+                            )
+                            or re.search(r"UE\s+==>\s+USE, DUE", line)
+                        ):
+                            continue
+
+                    codespell += line + "\n"
+
+            for codespell_entry in codespell.split("\n"):
+                if "==>" in codespell:
+                    yield LinterError(
+                        codespell,
+                        file=codespell_entry.split(":")[0],
+                        plugin=self.name,
+                    )
+                elif "Traceback (most recent call last):" in codespell:
+                    yield LinterError(
+                        codespell,
+                        plugin=self.name,
+                    )


### PR DESCRIPTION
**What**:

Switched spelling plugin to be `FilesPlugin` based because the `FilePlugin` based approach was too slow

Closes: Jira VTD-1656

**Why**:

`FilePlugin` approach took upwards of 2 hours to finish a full run.
Current runtime (local) is about 4 minutes

**How**:

Tests have been adjusted accordingly.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
