### PR TITLE
Fix version_updated wrong exit code

### DIFF
--- a/tests/standalone_plugins/test_version_updated.py
+++ b/tests/standalone_plugins/test_version_updated.py
@@ -49,7 +49,7 @@ def setupgit(tmpdir: Path) -> None:
     test_file.write_text(
         'script_version("2021-03-02T12:11:43+0000");”\n'
         'script_tag(name:"last_modification", '
-        'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2021)");'
+        'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2021)");\n'
     )
     git("add", str(test_file))
     git("commit", "-m", "test")
@@ -60,7 +60,7 @@ def change_nothing(tmpdir: Path) -> None:
     test_file.write_text(
         'script_version("2021-03-02T12:11:43+0000");”\n'
         'script_tag(name:"last_modification", '
-        'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2021)");123'
+        'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2021)");123\n'
     )
     git("add", str(test_file))
     git("commit", "-m", "test_nothing")
@@ -71,7 +71,7 @@ def change_version(tmpdir: Path):
     test_file.write_text(
         'script_version("2021-03-02T12:11:43+0001");”\n'
         'script_tag(name:"last_modification", '
-        'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2021)");'
+        'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2021)");\n'
     )
     git("add", str(test_file))
     git("commit", "-m", "test_version")
@@ -82,7 +82,7 @@ def change_last_modification(tmpdir: Path):
     test_file.write_text(
         'script_version("2021-03-02T12:11:43+0000");”\n'
         'script_tag(name:"last_modification", '
-        'value:"2021-03-02 12:11:43 +0010 (Tue, 02 Mar 2021)");'
+        'value:"2021-03-02 12:11:43 +0010 (Tue, 02 Mar 2021)");\n'
     )
     git("add", str(test_file))
     git("commit", "-m", "test_last_modification")
@@ -93,7 +93,7 @@ def change_version_and_last_modification(tmpdir: Path):
     test_file.write_text(
         'script_version("2021-03-02T12:11:43+0001");\n'
         'script_tag(name:"last_modification", '
-        'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2022)");'
+        'value:"2021-03-02 12:11:43 +0001 (Tue, 02 Mar 2021)");\n'
     )
     git("add", str(test_file))
     git("commit", "-m", "test_both")

--- a/tests/standalone_plugins/test_version_updated.py
+++ b/tests/standalone_plugins/test_version_updated.py
@@ -91,7 +91,7 @@ def change_last_modification(tmpdir: Path):
 def change_version_and_last_modification(tmpdir: Path):
     test_file = tmpdir / "test.nasl"
     test_file.write_text(
-        'script_version("2021-03-02T12:11:43+0001");\n”'
+        'script_version("2021-03-02T12:11:43+0001");\n'
         'script_tag(name:"last_modification", '
         'value:"2021-03-02 12:11:43 +0000 (Tue, 02 Mar 2022)");'
     )
@@ -137,7 +137,7 @@ class TestVersionChanged(unittest.TestCase):
         with tempgitdir() as tmpdir:
             setupgit(tmpdir)
             change_version_and_last_modification(tmpdir)
-            parsed_args = parse_args(["-c", "HEAD"])
+            parsed_args = parse_args(["-c", "HEAD~1"])
             self.assertTrue(
                 check_version_updated(
                     parsed_args.files, parsed_args.commit_range

--- a/troubadix/standalone_plugins/version_updated.py
+++ b/troubadix/standalone_plugins/version_updated.py
@@ -144,7 +144,7 @@ def main() -> int:
         return 1
 
     parsed_args = parse_args(args)
-    if check_version_updated(parsed_args.files, parsed_args.commit_range):
+    if not check_version_updated(parsed_args.files, parsed_args.commit_range):
         return 2
 
     return 0


### PR DESCRIPTION
**What**:

Inverted the if statement in main to produce the expected exit code.

**Why**:

The check was inverted and would return 2 for success and 0 for error, this would break the QA workflow.

**How**:

Added tests to prevent regression

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
