### PR TITLE
Add: Exception to badwords plugin

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -50,6 +50,7 @@ EXCEPTIONS = [
     "openvas-cli",
     "openvas-manager",
     "openvassd",
+    "openvasd",
     "lists.wald.intevation.org",
     "lib64openvas-devel",
     "lib64openvas6",


### PR DESCRIPTION
**What**:
This PR adds an exception to the badwords plugin.

**Why**:
See pipeline of https://github.com/greenbone/vulnerability-tests/pull/561, because http://www.slackware.com/security/viewer.php?l=slackware-security&y=2009&m=slackware-security.603376 contains `openvasd`.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
