### PR TITLE
Fix valid_script_tag_names.py and add test cases.

### DIFF
--- a/tests/plugins/test_valid_script_tag_names.py
+++ b/tests/plugins/test_valid_script_tag_names.py
@@ -1,0 +1,106 @@
+#  Copyright (c) 2022 Greenbone Networks GmbH
+#
+#  SPDX-License-Identifier: GPL-3.0-or-later
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from pathlib import Path
+
+from troubadix.plugin import LinterError
+from troubadix.plugins.valid_script_tag_names import CheckValidScriptTagNames
+
+from . import PluginTestCase
+
+
+class CheckValidScriptTagNamesTestCase(PluginTestCase):
+    def test_ok_nonewline(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            'script_tag(name:"vuldetect", value:"Without newline");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckValidScriptTagNames(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_ok_newline(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            'script_tag(name:"vuldetect", value:"With\nnewline");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckValidScriptTagNames(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_nok_nonewline(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            'script_tag(name:"vulndetect", value:"Without newline");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckValidScriptTagNames(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "The script_tag name 'vulndetect' is not allowed.",
+            results[0].message,
+        )
+
+    def test_nok_newline(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            'script_tag(name:"vulndetect", value:"With\nnewline");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckValidScriptTagNames(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "The script_tag name 'vulndetect' is not allowed.",
+            results[0].message,
+        )

--- a/troubadix/plugins/valid_script_tag_names.py
+++ b/troubadix/plugins/valid_script_tag_names.py
@@ -19,30 +19,8 @@ import re
 from pathlib import Path
 from typing import Iterator
 
+from troubadix.helper.patterns import _get_tag_pattern
 from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
-
-
-class AllScriptTagsPattern:
-    instance = False
-
-    def __init__(self) -> None:
-
-        self.pattern = re.compile(
-            pattern=(
-                r'script_tag\(\s*name\s*:\s*(?P<quote>[\'"])'
-                r"(?P<name>[a-zA-Z0-9\s\+\-\_]+)(?P=quote)\s*.+\s*\)\s*;"
-            ),
-            # flags=re.MULTILINE, # It seems that there is no multiline
-            # script_tag here
-        )
-        self.instance = self
-
-
-def get_all_tag_patterns() -> re.Pattern:
-    """Get all script tags **without** matching the value!!!"""
-    if AllScriptTagsPattern.instance:
-        return AllScriptTagsPattern.instance.pattern
-    return AllScriptTagsPattern().pattern
 
 
 class CheckValidScriptTagNames(FileContentPlugin):
@@ -107,7 +85,9 @@ class CheckValidScriptTagNames(FileContentPlugin):
             "solution_method",
         ]
 
-        matches = get_all_tag_patterns().finditer(file_content)
+        matches = _get_tag_pattern(name=r".+?", flags=re.S).finditer(
+            file_content
+        )
 
         if matches:
             for match in matches:

--- a/troubadix/plugins/valid_script_tag_names.py
+++ b/troubadix/plugins/valid_script_tag_names.py
@@ -111,7 +111,6 @@ class CheckValidScriptTagNames(FileContentPlugin):
 
         if matches:
             for match in matches:
-                # print(match)
                 if match.group("name") not in allowed_script_tag_names:
                     yield LinterError(
                         f"The script_tag name '{match.group('name')}' "


### PR DESCRIPTION
**What**:

The plugin had missed to report a wrongly used script_tag() if it contained a newline because of an insufficient regex used in the custom written functions which got replaced by a helper function now.

- Closes: VTD-1667
- Part of: VTD-1616

**Why**:

The previous used functions in that plugin didn't took tags like e.g. the following below including newlines into account which caused false negatives in comparison to the old QA.

```
  script_tag(name:"vuldetect", value:"Mylongdescriptionwitha
  newline in between.");
```

**How**:

- :robot:
- Also ran `troubadix -d nasl/common/ --include-tests check_valid_script_tag_names -v` to check if no false positives are showing up

**Checklist**:

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
