### PR TITLE
Fix: Spelling plugin duplicate output

### DIFF
--- a/tests/plugins/test_spelling.py
+++ b/tests/plugins/test_spelling.py
@@ -40,12 +40,23 @@ class CheckSpellingTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 4)
+
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            f"{nasl_file}:1: soltuion ==> solution\n"
-            f"{nasl_file}:1: aviaalable ==> available\n"
-            f"{nasl_file}:2: upated ==> updated\n",
+            f"{nasl_file}:1: soltuion ==> solution",
             results[0].message,
+        )
+
+        self.assertIsInstance(results[1], LinterError)
+        self.assertEqual(
+            f"{nasl_file}:1: aviaalable ==> available",
+            results[1].message,
+        )
+
+        self.assertIsInstance(results[2], LinterError)
+        self.assertEqual(
+            f"{nasl_file}:2: upated ==> updated",
+            results[2].message,
         )
 
     def test_local_files_nok(self):
@@ -63,6 +74,6 @@ class CheckSpellingTestCase(PluginTestCase):
         self.assertEqual(len(results), 2)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            f"{nasl_file}:2: upated ==> updated\n",
+            f"{nasl_file}:2: upated ==> updated",
             results[0].message,
         )

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -230,7 +230,7 @@ class CheckSpelling(FilesPlugin):
             for codespell_entry in codespell.split("\n"):
                 if "==>" in codespell:
                     yield LinterError(
-                        codespell,
+                        codespell_entry,
                         file=codespell_entry.split(":")[0],
                         plugin=self.name,
                     )


### PR DESCRIPTION
**What**:

Fixed duplicate output of spelling plugin

Jira: VTD-1668

**Why**:

After switching to `FilesPlugin` in #334 we had duplicated output

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
