### PR TITLE
Fix: Trailing whitespace not detected in script tag value

### DIFF
--- a/tests/plugins/test_script_tag_whitespaces.py
+++ b/tests/plugins/test_script_tag_whitespaces.py
@@ -73,3 +73,15 @@ class CheckScriptTagWhitespacesTestCase(PluginTestCase):
 
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
+
+    def test_trailing_whitespace_newline(self):
+        content = 'script_tag(name: "foo", value:"foo\nbar\n");'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptTagWhitespaces(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)

--- a/troubadix/plugins/script_tag_whitespaces.py
+++ b/troubadix/plugins/script_tag_whitespaces.py
@@ -43,9 +43,9 @@ class CheckScriptTagWhitespaces(FileContentPlugin):
         )
 
         for match in matches:
-            if re.match(r"^\s+.*", match.group("value")) or re.match(
-                r".*\s+$", match.group("value")
-            ):
+            if re.match(
+                r"^\s+.*", match.group("value"), flags=re.S
+            ) or re.match(r".*\s+$", match.group("value"), flags=re.S):
                 yield LinterError(
                     f"{match.group(0)}: value contains a leading or"
                     " trailing whitespace character",

--- a/troubadix/plugins/script_tag_whitespaces.py
+++ b/troubadix/plugins/script_tag_whitespaces.py
@@ -43,9 +43,9 @@ class CheckScriptTagWhitespaces(FileContentPlugin):
         )
 
         for match in matches:
-            if re.match(
-                r"^\s+.*", match.group("value"), flags=re.S
-            ) or re.match(r".*\s+$", match.group("value"), flags=re.S):
+            if re.match(r"^\s+.*", match.group("value")) or re.match(
+                r".*\s+$", match.group("value"), flags=re.S
+            ):
                 yield LinterError(
                     f"{match.group(0)}: value contains a leading or"
                     " trailing whitespace character",


### PR DESCRIPTION
**What**:

Fixed script tag value trailing whitespace check to work with newline containing values.
Jira: VTD-1669

**Why**:
False negative when compared to old QA

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
