### PR TITLE
Fix: Spelling check has too many results with trailing newline

### DIFF
--- a/tests/plugins/test_spelling.py
+++ b/tests/plugins/test_spelling.py
@@ -39,7 +39,7 @@ class CheckSpellingTestCase(PluginTestCase):
 
         results = list(plugin.run())
 
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 3)
 
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
@@ -71,7 +71,7 @@ class CheckSpellingTestCase(PluginTestCase):
 
         codespell_additions.unlink()
 
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             f"{nasl_file}:2: upated ==> updated",

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -235,7 +235,7 @@ class CheckSpelling(FilesPlugin):
 
                     codespell += line + "\n"
 
-            for codespell_entry in codespell.split("\n"):
+            for codespell_entry in codespell.splitlines():
                 if "==>" in codespell:
                     yield LinterError(
                         codespell_entry,


### PR DESCRIPTION
**What**:

Spelling check would report 1 additional result with a trailing newline from codespell output.

**Why**:

Jira: VTD-1703

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
