### PR TITLE
Fix: Product name of AlmaLinux in two plugins.

### DIFF
--- a/troubadix/plugins/script_family.py
+++ b/troubadix/plugins/script_family.py
@@ -26,7 +26,7 @@ from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
 
 VALID_FAMILIES = [
     "AIX Local Security Checks",
-    "Alma Linux Local Security Checks",
+    "AlmaLinux Local Security Checks",
     "Amazon Linux Local Security Checks",
     "Brute force attacks",
     "Buffer overflow",

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -313,9 +313,9 @@ class CheckValidOID(FileContentPlugin):
                     return
 
             elif vendor_number == "15":
-                if family != f"Alma Linux {family_template}":
+                if family != f"AlmaLinux {family_template}":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} Alma Linux "
+                        f"script_oid() {is_using_reserved} AlmaLinux "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,


### PR DESCRIPTION
**What**:

As mentioned in a PR review of greenbone/notus-generator#440 there is no space in the product name as seen on e.g.:
- https://almalinux.org/
- https://en.wikipedia.org/wiki/AlmaLinux

which should be also reflected here.

**Why**:

Consistency reasons

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
