### PR TITLE
Fix: Possible false positive in grammar plugin.

### DIFF
--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -127,6 +127,10 @@ class CheckGrammar(FilePlugin):
         if "an attackers choise" in match:
             return True
 
+        # nb: The regex to catch "this files" might catch this wrongly...
+        if "this filesystem" in match:
+            return True
+
         if (
             "2012/gb_VMSA-2010-0007.nasl" in nasl_file
             and "e. VMware VMnc Codec heap overflow vulnerabilities\n\n"


### PR DESCRIPTION
**What**:

- Add an exclusion after #378
- Parity PR to greenbone/vulnerability-tests#1175

**Why**:

Exclude a few false positives

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
