### PR TITLE
Change: Use re.IGNORECASE for grammar exclusions

### DIFF
--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -116,6 +116,7 @@ class CheckGrammar(FilePlugin):
             "a multiple keyboard ",
             "A A S Application Access Server",
             "a Common Vulnerabilities and Exposures",
+            "Multiple '/' Vulnerability",
             "an attackers choise",
             "multiple error handling vulnerabilities",
             # Like seen in 2022/debian/deb_dla_2981.nasl
@@ -127,7 +128,7 @@ class CheckGrammar(FilePlugin):
             # 2021/ubuntu/gb_ubuntu_USN_4711_1.nasl
             "An attacker with access to at least one LUN in a multiple",
             # nb: The regex to catch "this files" might catch this wrongly...
-            re.compile(r"th(is|ese)\s+filesystem"),
+            re.compile(r"th(is|ese)\s+filesystem", re.IGNORECASE),
             # Like seen in e.g. 2008/freebsd/freebsd_mod_php4-twig.nasl
             re.compile(r'(\s+|")[Aa]\s+multiple\s+of'),
             # WITH can be used like e.g. the following which is valid:
@@ -135,8 +136,13 @@ class CheckGrammar(FilePlugin):
             # see e.g. gb_sles_2021_3215_1.nasl or gb_sles_2021_2320_1.nasl
             re.compile(r"with\s+WITH"),
             # Valid sentences
-            re.compile(r"these\s+error\s+(messages|reports|conditions)"),
-            re.compile(r"these\s+file\s+(permissions|overwrites|names)"),
+            re.compile(
+                r"these\s+error\s+(messages|reports|conditions)", re.IGNORECASE
+            ),
+            re.compile(
+                r"these\s+file\s+(permissions|overwrites|names|includes)",
+                re.IGNORECASE,
+            ),
             (
                 "2012/gb_VMSA-2010-0007.nasl",
                 "e. VMware VMnc Codec heap overflow vulnerabilities\n\n"


### PR DESCRIPTION
Add: Additional grammar exclusion
Fix: Missing grammar exclusion which got dropped previously

**What**
- Some of the pattern should be checked case insensitive
- In 9c81e332f0941d5b9377119d1b9cacbe7d66eefb (from #381) one exclusion pattern seems to have been dropped accidentally

**Why**:
To solve the following false positives:

```
2022-09-14T21:00:17.9456275Z ℹ Checking pre2008/apache_slash.nasl (36913/98057)
2022-09-14T21:00:17.9471739Z ℹ     Results for plugin check_grammar
2022-09-14T21:00:17.9473703Z ×         VT/Include has the following grammar problem: # Description: Check for
2022-09-14T21:00:17.9475426Z            Apache Multiple '/' Vulnerability
2022-09-14T21:00:17.9476569Z           #
2022-09-14T21:00:17.9493818Z ℹ Checking gsf/2019/cisco/gb_cisco_nx_os_cisco-sa-20190515-nxos-file-write.nasl 
2022-09-14T21:00:17.9536835Z   (50485/98057)
2022-09-14T21:00:17.9537689Z ℹ     Results for plugin check_grammar
2022-09-14T21:00:17.9538329Z ×         VT/Include has the following grammar problem:   file system including 
2022-09-14T21:00:17.9539063Z           system files. These file overwrites by the attacker are accomplished a
2022-09-14T21:00:17.9539681Z           t the root privilege
2022-09-14T21:00:17.9540468Z ℹ Checking pre2008/oracle9i_soapconfig.nasl (65536/98057)
2022-09-14T21:00:17.9541059Z ℹ     Results for plugin check_grammar
2022-09-14T21:00:17.9541731Z ×         VT/Include has the following grammar problem:   access some configurat
2022-09-14T21:00:17.9542261Z           ion files. These file includes detailed
2022-09-14T21:00:17.9542864Z ℹ Checking Policy/Linux/Setup/mounting_udf.nasl (72285/98057)
2022-09-14T21:00:17.9543486Z ℹ     Results for plugin check_grammar
2022-09-14T21:00:17.9544231Z ×         VT/Include has the following grammar problem: storage on a broad range
2022-09-14T21:00:17.9544890Z            of media. This filesystem type is necessary to support writing DVDs a
2022-09-14T21:00:17.9545375Z           nd newer
```

**How**:
N/A

**Checklist**:
- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
