### PR TITLE
Change: Make one grammar exclusion pattern more strict.

### DIFF
--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -112,7 +112,7 @@ class CheckGrammar(FilePlugin):
         # strings, regex patterns and Tuples
         # in the format of: (filename, content)
         known_fps = [
-            re.compile(r"[Aa] few "),
+            re.compile(r'(\s+|"|#\s*)[Aa] few (issues|vulnerabilities)'),
             "a multiple keyboard ",
             "A A S Application Access Server",
             "a Common Vulnerabilities and Exposures",


### PR DESCRIPTION
**What**:
- See title
- Parity PR to greenbone/vulnerability-tests#1258

**Why**:
Previously to this change the following wasn't detected because the exclusion pattern `a few` matched against `a few CMS`:

```
ℹ Checking common/2018/phpunit/gb_phpunit_rce.nasl (39872/98072)
ℹ     Results for plugin check_grammar
×         VT/Include has the following grammar problem: # First fill the known location of a few CMS and CMS plugins shipping this files
```

**How**:
1. Ran Troubadix against the whole feed
2. Checked that no reports from the grammar plugin are reported
3. Updated the regex and re-ran Troubadix, now the grammar problem above is correctly reported while no additional false positives are happening

**Checklist**:
- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation