### PR TITLE
Add: Additional exclusions to the spelling plugin.

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -259,6 +259,19 @@ class CheckSpelling(FilesPlugin):
                         if re.search(r"[Uu]nsecure\s+==>\s+[Ii]nsecure", line):
                             continue
 
+                    # NAM / nam is the abbreviation of these products. In
+                    # netop_infopublic.nasl there is a "nam" parameter.
+                    if (
+                        re.search(
+                            r"gb_((cisco|solarwinds)_nam|"
+                            "netiq_access_manager)_",
+                            line,
+                        )
+                        or "/netop_infopublic.nasl" in line
+                    ):
+                        if re.search(r"nam\s+==>\s+name", line, re.IGNORECASE):
+                            continue
+
                     codespell += line + "\n"
 
             for codespell_entry in codespell.splitlines():


### PR DESCRIPTION
**What**:
See title

Notes:
- No new release required, there will be at least one follow-up PR for syncing the current `codespell.*` files from the vulerability-tests repo.
- Parity PR to greenbone/vulnerability-tests#1319
- Some further improvements for this plugin are not tracked in VTD-1773

**Why**:
Exclude a few false positives in a more generic way.

**How**:
Run the spelling plugin against the whole feed and less spelling issues should be reported.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
