### PR TITLE
Fix: Enable the dependency check to work on multiline entries

### DIFF
--- a/troubadix/plugins/dependencies.py
+++ b/troubadix/plugins/dependencies.py
@@ -21,9 +21,8 @@ import re
 from pathlib import Path
 from typing import Iterator
 
-from troubadix.helper import SpecialScriptTag
-from troubadix.helper.helper import is_enterprise_folder, FEED_VERSIONS
-from troubadix.helper.patterns import get_special_script_tag_pattern
+from troubadix.helper.helper import FEED_VERSIONS, is_enterprise_folder
+from troubadix.helper.patterns import _get_special_script_tag_pattern
 from troubadix.plugin import (
     FilePlugin,
     LinterError,
@@ -46,8 +45,8 @@ class CheckDependencies(FilePlugin):
         if self.context.nasl_file.suffix == ".inc":
             return
 
-        dependencies_pattern = get_special_script_tag_pattern(
-            SpecialScriptTag.DEPENDENCIES
+        dependencies_pattern = _get_special_script_tag_pattern(
+            "dependencies", flags=re.DOTALL | re.MULTILINE
         )
 
         root = self.context.root


### PR DESCRIPTION
**What**:
Fixes the false negatives when checking dependencies that are spread over multiple lines in `script_dependency` tags

**Why**:

Closes: VTD-1769

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
