### PR TITLE
Fix: Allow multiline dependencies with inline comments

### DIFF
--- a/tests/plugins/test_dependencies.py
+++ b/tests/plugins/test_dependencies.py
@@ -196,16 +196,16 @@ class CheckDependenciesTestCase(PluginTestCase):
     def test_inline_comment_dependency(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "example.inc"
-            example2 = tmpdir / "common" / "example2.inc"
+            example = tmpdir / "common" / "example.nasl"
+            example2 = tmpdir / "common" / "example2.nasl"
             example.parent.mkdir(parents=True)
             example.touch()
             example2.touch()
             content = (
                 'script_tag(name:"cvss_base", value:"4.0");\n'
                 'script_tag(name:"summary", value:"Foo Bar...");\n'
-                'script_dependencies("example.inc", #Comment\n'
-                '"example2.inc");\n'
+                'script_dependencies("example.nasl", #Comment\n'
+                '"example2.nasl");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir
@@ -219,14 +219,14 @@ class CheckDependenciesTestCase(PluginTestCase):
     def test_inline_comment_dependency_nok(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "example.inc"
+            example = tmpdir / "common" / "example.nasl"
             example.parent.mkdir(parents=True)
             example.touch()
             content = (
                 'script_tag(name:"cvss_base", value:"4.0");\n'
                 'script_tag(name:"summary", value:"Foo Bar...");\n'
-                'script_dependencies("example.inc", #Comment\n '
-                '"example2.inc");\n'
+                'script_dependencies("example.nasl", #Comment\n '
+                '"example2.nasl");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir

--- a/tests/plugins/test_dependencies.py
+++ b/tests/plugins/test_dependencies.py
@@ -192,3 +192,47 @@ class CheckDependenciesTestCase(PluginTestCase):
                 "not be found within the VTs.",
                 results[0].message,
             )
+
+    def test_inline_comment_dependency(self):
+        with self.create_directory() as tmpdir:
+            path = tmpdir / "file.nasl"
+            example = tmpdir / "common" / "example.inc"
+            example2 = tmpdir / "common" / "example2.inc"
+            example.parent.mkdir(parents=True)
+            example.touch()
+            example2.touch()
+            content = (
+                'script_tag(name:"cvss_base", value:"4.0");\n'
+                'script_tag(name:"summary", value:"Foo Bar...");\n'
+                'script_dependencies("example.inc", #Comment\n'
+                '"example2.inc");\n'
+            )
+            fake_context = self.create_file_plugin_context(
+                nasl_file=path, file_content=content, root=tmpdir
+            )
+            plugin = CheckDependencies(fake_context)
+
+            results = list(plugin.run())
+
+            self.assertEqual(len(results), 0)
+
+    def test_inline_comment_dependency_nok(self):
+        with self.create_directory() as tmpdir:
+            path = tmpdir / "file.nasl"
+            example = tmpdir / "common" / "example.inc"
+            example.parent.mkdir(parents=True)
+            example.touch()
+            content = (
+                'script_tag(name:"cvss_base", value:"4.0");\n'
+                'script_tag(name:"summary", value:"Foo Bar...");\n'
+                'script_dependencies("example.inc", #Comment\n '
+                '"example2.inc");\n'
+            )
+            fake_context = self.create_file_plugin_context(
+                nasl_file=path, file_content=content, root=tmpdir
+            )
+            plugin = CheckDependencies(fake_context)
+
+            results = list(plugin.run())
+
+            self.assertEqual(len(results), 1)

--- a/troubadix/plugins/dependencies.py
+++ b/troubadix/plugins/dependencies.py
@@ -62,7 +62,7 @@ class CheckDependencies(FilePlugin):
                 dependencies = []
 
                 for line in match.group("value").splitlines():
-                    subject = line[: line.find("#")] if "#" in line else line
+                    subject = line[: line.index("#")] if "#" in line else line
                     _dependencies = re.sub(r'[\'"\s]', "", subject).split(",")
                     dependencies += [dep for dep in _dependencies if dep != ""]
 

--- a/troubadix/plugins/dependencies.py
+++ b/troubadix/plugins/dependencies.py
@@ -58,9 +58,13 @@ class CheckDependencies(FilePlugin):
             if match:
                 # Remove single and/or double quotes, spaces
                 # and create a list by using the comma as a separator
-                dependencies = re.sub(
-                    r'[\'"\s]', "", match.group("value")
-                ).split(",")
+                # additionally, check and filter for inline comments
+                dependencies = []
+
+                for line in match.group("value").splitlines():
+                    subject = line[: line.find("#")] if "#" in line else line
+                    _dependencies = re.sub(r'[\'"\s]', "", subject).split(",")
+                    dependencies += [dep for dep in _dependencies if dep != ""]
 
                 for dep in dependencies:
                     # TODO: gsf/PCIDSS/PCI-DSS.nasl,


### PR DESCRIPTION
**What**:

Fixes false positives in the dependency check if inline comments are present in the parameter list

**Why**:

Closes: VTD-1782

**How**:

Output before PR:
```
ℹ Start linting 131121 files ... 
ℹ Time elapsed: 0:00:10.588791
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_dependencies                                      2      433
  -------------------------------------------------------------------
ℹ sum                                                     2      433
```

Output with PR:
```
ℹ Start linting 131121 files ... 
ℹ Time elapsed: 0:00:10.866805
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
⚠ check_dependencies                                      0      433
  -------------------------------------------------------------------
ℹ sum                                                     0      433
```


**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
