### PR TITLE
Add: Additional spelling exclusions

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -160,6 +160,9 @@ exceptions = [
     PatternInFileCheck(
         "/netop_infopublic.nasl", r"nam\s+==>\s+name", flags=re.IGNORECASE
     ),
+    # Product names used in a few VTs (no re.IGNORECASE is expected)
+    PatternsCheck([r"renderD\s+==>\s+rendered", r"VertX\s+==>\s+vertex"]),
+    PatternInFileCheck("_vertx_", r"vertx\s+==>\s+vertex"),
 ]
 
 


### PR DESCRIPTION
**What**:
See title

**Why**:
Reduce false positives

**How**:

Before this PR:

```
$ troubadix -d nasl/common/ --include-tests check_spelling -v
ℹ Start linting 92893 files ... 
ℹ Run plugin check_spelling
ℹ     Results for plugin check_spelling
×         nasl/common/2017/opensuse/gb_opensuse_2017_1140_1.nasl:88: renderD ==> rendered
×         nasl/common/gsf/2022/f5/gb_f5_big_ip_K63771715.nasl:56: renderD ==> rendered
×         nasl/common/gb_hid_vertx_discoveryd_detect.nasl:4: VertX ==> vertex
×         nasl/common/gb_hid_vertx_discoveryd_detect.nasl:38: VertX ==> vertex
×         nasl/common/gb_hid_vertx_discoveryd_detect.nasl:40: VertX ==> vertex
×         nasl/common/gb_hid_vertx_discoveryd_detect.nasl:42: VertX ==> vertex
×         nasl/common/gb_hid_vertx_discoveryd_detect.nasl:112: vertx ==> vertex
×         nasl/common/gb_hid_vertx_discoveryd_detect.nasl:114: vertx ==> vertex
×         nasl/common/gb_hid_vertx_discoveryd_detect.nasl:119: VertX ==> vertex
×         nasl/common/gsf/2018/hid/gb_hid_vertx_rce_vuln.nasl:4: VertX ==> vertex
×         nasl/common/gsf/2018/hid/gb_hid_vertx_rce_vuln.nasl:27: vertx ==> vertex
×         nasl/common/gsf/2018/hid/gb_hid_vertx_rce_vuln.nasl:42: VertX ==> vertex
×         nasl/common/gsf/2018/hid/gb_hid_vertx_rce_vuln.nasl:51: VertX ==> vertex
×         nasl/common/gsf/2018/hid/gb_hid_vertx_rce_vuln.nasl:56: VertX ==> vertex
×         nasl/common/gsf/2018/hid/gb_hid_vertx_rce_vuln.nasl:57: VertX ==> vertex
×         nasl/common/2017/opensuse/gb_opensuse_2017_1215_1.nasl:80: renderD ==> rendered
×         nasl/common/2017/opensuse/gb_opensuse_2017_1215_1.nasl:86: renderD ==> rendered
×         nasl/common/2017/opensuse/gb_opensuse_2017_1633_1.nasl:62: renderD ==> rendered
ℹ Time elapsed: 0:01:54.675719
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_spelling                                         18        0
  -------------------------------------------------------------------
ℹ sum                                                    18        0
```

After his PR:

```
$ troubadix -d nasl/common/ --include-tests check_spelling -v
ℹ Start linting 92893 files ... 
ℹ Time elapsed: 0:01:56.393567
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
  -------------------------------------------------------------------
ℹ sum                                                     0        0
```

**Checklist**:

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
