### PR TITLE
Fix: Missing escaping of a dot in a regex

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -132,7 +132,7 @@ exceptions = [
     # Similar to the one above for e.g. SLES.
     # Also exclude "tre", because it's a package name.
     PatternInFilePatternCheck(
-        r"mgasa-\d{4}-\d{4}.nasl",
+        r"mgasa-\d{4}-\d{4}\.nasl",
         r"(hda|tre|conexant)\s+==>\s+(had|tree|connexant)",
         file_pattern_flags=re.IGNORECASE,
     ),


### PR DESCRIPTION
**What**:
The dot is part of a filename so it should be escaped.

**Why**:
N/A

**How**:
N/A

**Checklist**:

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation