### PR TITLE
Add: Check for malformed script_dependency  values

### DIFF
--- a/tests/plugins/test_malformed_dependencies.py
+++ b/tests/plugins/test_malformed_dependencies.py
@@ -31,7 +31,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         content = (
             'script_tag(name:"cvss_base", value:"4.0");\n'
             'script_tag(name:"summary", value:"Foo Bar.");\n'
-            'script_dependencies("example.inc", "example2.inc");\n'
+            'script_dependencies("example.nasl", "example2.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content, root=here
@@ -47,7 +47,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         content = (
             'script_tag(name:"cvss_base", value:"4.0");\n'
             'script_tag(name:"summary", value:"Foo Bar.");\n'
-            'script_dependencies("example.inc,example2.inc");\n'
+            'script_dependencies("example.nasl,example2.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content, root=here
@@ -58,7 +58,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
 
         expected_result = (
             "The script dependency value is malformed and contains a "
-            "comma in the dependency value: 'example.inc,example2.inc'"
+            "comma in the dependency value: 'example.nasl,example2.nasl'"
         )
 
         self.assertEqual(len(results), 1)
@@ -70,8 +70,8 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         content = (
             'script_tag(name:"cvss_base", value:"4.0");\n'
             'script_tag(name:"summary", value:"Foo Bar.");\n'
-            'script_dependencies("example.inc,example2.inc",'
-            ' "example3.inc");\n'
+            'script_dependencies("example.nasl,example2.nasl",'
+            ' "example3.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content, root=here
@@ -82,7 +82,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
 
         expected_result = (
             "The script dependency value is malformed and contains a "
-            "comma in the dependency value: 'example.inc,example2.inc'"
+            "comma in the dependency value: 'example.nasl,example2.nasl'"
         )
 
         self.assertEqual(len(results), 1)
@@ -94,7 +94,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         content = (
             'script_tag(name:"cvss_base", value:"4.0");\n'
             'script_tag(name:"summary", value:"Foo Bar.");\n'
-            'script_dependencies("example.inc example2.inc");\n'
+            'script_dependencies("example.nasl example2.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content, root=here
@@ -106,7 +106,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         expected_result = (
             "The script dependency value is malformed and contains "
             "whitespace within the dependency value: "
-            "'example.inc example2.inc'"
+            "'example.nasl example2.nasl'"
         )
 
         self.assertEqual(len(results), 1)
@@ -118,7 +118,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         content = (
             'script_tag(name:"cvss_base", value:"4.0");\n'
             'script_tag(name:"summary", value:"Foo Bar.");\n'
-            'script_dependencies("example.inc, example2.inc");\n'
+            'script_dependencies("example.nasl, example2.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content, root=here
@@ -129,13 +129,13 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
 
         expected_result_1 = (
             "The script dependency value is malformed and contains "
-            "a comma in the dependency value: 'example.inc, example2.inc'"
+            "a comma in the dependency value: 'example.nasl, example2.nasl'"
         )
 
         expected_result_2 = (
             "The script dependency value is malformed and contains "
             "whitespace within the dependency value: "
-            "'example.inc, example2.inc'"
+            "'example.nasl, example2.nasl'"
         )
 
         self.assertEqual(len(results), 2)
@@ -149,7 +149,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         content = (
             'script_tag(name:"cvss_base", value:"4.0");\n'
             'script_tag(name:"summary", value:"Foo Bar.");\n'
-            'script_dependencies("example .inc", "example2.inc");\n'
+            'script_dependencies("example .nasl", "example2.nasl");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content, root=here
@@ -160,7 +160,7 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
 
         expected_result = (
             "The script dependency value is malformed and contains "
-            "whitespace within the dependency value: 'example .inc'"
+            "whitespace within the dependency value: 'example .nasl'"
         )
 
         self.assertEqual(len(results), 1)

--- a/tests/plugins/test_malformed_dependencies.py
+++ b/tests/plugins/test_malformed_dependencies.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+from troubadix.plugin import LinterError
+from troubadix.plugins.malformed_dependencies import CheckMalformedDependencies
+
+from . import PluginTestCase
+
+here = Path(__file__).parent
+
+
+class CheckMalformedDependenciesTestCase(PluginTestCase):
+    def test_ok(self):
+        path = here / "file.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_dependencies("example.inc", "example2.inc");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content, root=here
+        )
+        plugin = CheckMalformedDependencies(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_nok_1(self):
+        path = here / "file.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_dependencies("example.inc, example2.inc");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content, root=here
+        )
+        plugin = CheckMalformedDependencies(fake_context)
+
+        results = list(plugin.run())
+
+        expected_result = (
+            "The script dependency value is malformed and "
+            "contains an invalid ratio of quoted entries to commas"
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(results[0].message, expected_result)
+
+    def test_nok_2(self):
+        path = here / "file.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_dependencies("example.inc, example2.inc",'
+            ' "example3.inc");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content, root=here
+        )
+        plugin = CheckMalformedDependencies(fake_context)
+
+        results = list(plugin.run())
+
+        expected_result = (
+            "The script dependency value is malformed and "
+            "contains an invalid ratio of quoted entries to commas"
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(results[0].message, expected_result)

--- a/tests/plugins/test_malformed_dependencies.py
+++ b/tests/plugins/test_malformed_dependencies.py
@@ -143,3 +143,26 @@ class CheckMalformedDependenciesTestCase(PluginTestCase):
         self.assertIsInstance(results[1], LinterError)
         self.assertEqual(results[0].message, expected_result_1)
         self.assertEqual(results[1].message, expected_result_2)
+
+    def test_nok_5(self):
+        path = here / "file.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"4.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_dependencies("example .inc", "example2.inc");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content, root=here
+        )
+        plugin = CheckMalformedDependencies(fake_context)
+
+        results = list(plugin.run())
+
+        expected_result = (
+            "The script dependency value is malformed and contains "
+            "whitespace within the dependency value: 'example .inc'"
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(results[0].message, expected_result)

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -40,6 +40,7 @@ from .grammar import CheckGrammar
 from .http_links_in_tags import CheckHttpLinksInTags
 from .illegal_characters import CheckIllegalCharacters
 from .log_messages import CheckLogMessages
+from .malformed_dependencies import CheckMalformedDependencies
 from .misplaced_compare_in_if import CheckMisplacedCompareInIf
 from .missing_desc_exit import CheckMissingDescExit
 from .missing_tag_solution import CheckMissingTagSolution
@@ -100,6 +101,7 @@ _FILE_PLUGINS = [
     CheckHttpLinksInTags,
     CheckIllegalCharacters,
     CheckLogMessages,
+    CheckMalformedDependencies,
     CheckMisplacedCompareInIf,
     CheckMissingDescExit,
     CheckMissingTagSolution,

--- a/troubadix/plugins/malformed_dependencies.py
+++ b/troubadix/plugins/malformed_dependencies.py
@@ -23,10 +23,10 @@ from typing import Iterator
 from troubadix.helper.patterns import _get_special_script_tag_pattern
 from troubadix.plugin import FilePlugin, LinterError, LinterResult
 
-INNER_WHITESPACE_PATTERN = re.compile(r"^\s*[^\s]+\s*$")
 DEPENDENCY_ENTRY_PATTERN = re.compile(
     r'(?P<quote>[\'"])(?P<value>[^\'"]*)(?P=quote)'
 )
+WHITESPACE_PATTERN = re.compile(r"\s")
 
 
 class CheckMalformedDependencies(FilePlugin):
@@ -77,7 +77,7 @@ class CheckMalformedDependencies(FilePlugin):
                         plugin=self.name,
                     )
 
-                if not INNER_WHITESPACE_PATTERN.match(dependency_value):
+                if WHITESPACE_PATTERN.search(dependency_value):
                     yield LinterError(
                         "The script dependency value is malformed and "
                         "contains whitespace within the dependency value: "

--- a/troubadix/plugins/malformed_dependencies.py
+++ b/troubadix/plugins/malformed_dependencies.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=fixme
+
+import re
+from typing import Iterator
+
+from troubadix.helper.patterns import _get_special_script_tag_pattern
+from troubadix.plugin import FilePlugin, LinterError, LinterResult
+
+
+class CheckMalformedDependencies(FilePlugin):
+    name = "check_malformed_dependencies"
+
+    def run(
+        self,
+    ) -> Iterator[LinterResult]:
+        """This script checks whether the files used in script_dependencies()
+        exist on the local filesystem.
+        An error will be thrown if a dependency could not be found.
+        """
+
+        if self.context.nasl_file.suffix == ".inc":
+            return
+
+        dependencies_pattern = _get_special_script_tag_pattern(
+            "dependencies", flags=re.DOTALL | re.MULTILINE
+        )
+
+        file_content = self.context.file_content
+
+        matches = dependencies_pattern.finditer(file_content)
+
+        for match in matches:
+            if match:
+
+                tag_value = (
+                    f'"{match.group("value")}"' if match.group("value") else ""
+                )
+
+                quote_count = len(
+                    [char for char in tag_value if char in ['"', "'"]]
+                )
+                comma_count = len([char for char in tag_value if char == ","])
+
+                required_ratio = quote_count / 2 - 1
+                if quote_count >= 2 and comma_count != required_ratio:
+                    yield LinterError(
+                        "The script dependency value is malformed and "
+                        "contains an invalid ratio of quoted entries to commas",
+                        file=self.context.nasl_file,
+                        plugin=self.name,
+                    )


### PR DESCRIPTION
**What**:

Adds a plugin to check for dependencies which are malformed by being enumerated within a single pair of quotes.

**Why**:

Closes: VTD-444

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
