### PR TITLE
Change: Report both affected files in the Duplicated OID plugin.

### DIFF
--- a/tests/plugins/test_duplicate_oid.py
+++ b/tests/plugins/test_duplicate_oid.py
@@ -74,8 +74,10 @@ class CheckDuplicateOIDTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "OID 1.3.6.1.4.1.25623.1.0.100312 already used by "
-            "'test_files/nasl/21.04/fail.nasl'",
+            "OID 1.3.6.1.4.1.25623.1.0.100312 is duplicated in the following"
+            " files:\n"
+            "test_files/nasl/21.04/test.nasl\n"
+            "test_files/nasl/21.04/fail.nasl",
             results[0].message,
         )
 

--- a/troubadix/plugins/duplicate_oid.py
+++ b/troubadix/plugins/duplicate_oid.py
@@ -76,7 +76,9 @@ class CheckDuplicateOID(FilesPlugin):
                 mapping[oid] = nasl_file_root
             else:
                 yield LinterError(
-                    f"OID {oid} already used by '{mapping[oid]}'",
+                    f"OID {oid} is duplicated in the following files:\n"
+                    f"{nasl_file_root}\n"
+                    f"{mapping[oid]}",
                     file=nasl_file,
                     plugin=self.name,
                 )


### PR DESCRIPTION
**What**:

Before this PR:

```
ℹ Start linting 2 files ... 
ℹ Run plugin check_duplicate_oid
ℹ     Results for plugin check_duplicate_oid
×         OID 1.3.6.1.4.1.25623.1.0.95888 already used by 'common/compliance_tests.nasl'
ℹ Checking common/gsf/2009/opensuse/gb_suse_2008_056.nasl (1/2)
ℹ Checking common/compliance_tests.nasl (2/2)
ℹ Time elapsed: 0:00:00.018494
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_duplicate_oid                                     1        0
  -------------------------------------------------------------------
ℹ sum                                                     1        0
```

after this PR:

```
ℹ Start linting 2 files ... 
ℹ Run plugin check_duplicate_oid
ℹ     Results for plugin check_duplicate_oid
×         OID 1.3.6.1.4.1.25623.1.0.95888 is duplicated in the following files:
          common/compliance_tests.nasl
          common/gsf/2009/opensuse/gb_suse_2008_056.nasl
ℹ Checking common/compliance_tests.nasl (1/2)
ℹ Checking common/gsf/2009/opensuse/gb_suse_2008_056.nasl (2/2)
ℹ Time elapsed: 0:00:00.023228
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
× check_duplicate_oid                                     1        0
  -------------------------------------------------------------------
ℹ sum                                                     1        0
```

**Why**:

- Previously only one of both files have been printed out and you would need to grep for the OID to find the second one
- Now both files are printed out which makes a second step unnecessary / avoids additional work for info which is already there

**How**:

Change the OID in one VT to have a duplicated one and run Troubadix like e.g.:

```
troubadix -v --include-tests check_duplicate_oid --files nasl/common/gsf/2009/opensuse/gb_suse_2008_056.nasl nasl/common/compliance_tests.nasl
```

**Checklist**:

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation