### PR TITLE
Remove: Unused dictionaries in Duplicate OID plugin.

### DIFF
--- a/troubadix/plugins/duplicate_oid.py
+++ b/troubadix/plugins/duplicate_oid.py
@@ -31,9 +31,6 @@ from troubadix.plugin import FilesPlugin, LinterError, LinterResult
 OPENVAS_OID_PREFIX = r"1.3.6.1.4.1.25623.1.[0-9]+."
 OID_RE = re.compile(r"^1\.3\.6\.1\.4\.1\.25623\.1\.[0-9]+\.[\d.]+$")
 
-KNOWN_DUPS = {"1.3.6.1.4.1.25623.1.0.850001", "1.3.6.1.4.1.25623.1.0.95888"}
-KNOWN_ABSENTS = {"template.nasl"}
-
 
 class CheckDuplicateOID(FilesPlugin):
     name = "check_duplicate_oid"


### PR DESCRIPTION
**What**:

The `KNOWN_DUPS` and `KNOWN_ABSENTS` dicts seems to be currently unused (probably some leftovers from previous development) so just dropping them.

**Why**:

Clean up / remove unused code.

**How**:

N/A

**Checklist**:

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation