### PR TITLE
Remove: Unused constant and commented out import statement in Duplicate OID plugin.

### DIFF
--- a/troubadix/plugins/duplicate_oid.py
+++ b/troubadix/plugins/duplicate_oid.py
@@ -26,9 +26,6 @@ from troubadix.helper import (
 )
 from troubadix.plugin import FilesPlugin, LinterError, LinterResult
 
-# import json
-
-OPENVAS_OID_PREFIX = r"1.3.6.1.4.1.25623.1.[0-9]+."
 OID_RE = re.compile(r"^1\.3\.6\.1\.4\.1\.25623\.1\.[0-9]+\.[\d.]+$")
 
 


### PR DESCRIPTION
**What**:
- the use of `OPENVAS_OID_PREFIX` got dropped via #297 but the constant was left back. As it isn't used anymore it can be dropped
- the commented out import was probably a leftover from previous tests / development
- at some point in time we should consider to move `OID_RE` into `pattern.py` but for now this should be fine to keep it in the plugin itself

**Why**:

Clean up / remove unused code.

**How**:

N/A

**Checklist**:

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation