### PR TITLE
Fix: Typo and missing space in help output of no_solution standalone plugin

### DIFF
--- a/troubadix/standalone_plugins/no_solution.py
+++ b/troubadix/standalone_plugins/no_solution.py
@@ -92,7 +92,7 @@ def parse_args() -> Namespace:
         "--milestones",
         dest="milestones",
         help="Defines the milestones for which to report VTs "
-        "without a solution for, in months. VTs with no solution newer"
+        "without a solution for, in months. VTs with no solution newer "
         "than the smallest milestone will not be reported.",
         nargs="+",
         type=int,
@@ -106,7 +106,7 @@ def parse_args() -> Namespace:
         type=int,
         default=12,
         help="The threshold after which to assume no solution "
-        "will be provived anymore",
+        "will be provided anymore",
     )
 
     parser.add_argument(
@@ -115,7 +115,7 @@ def parse_args() -> Namespace:
         dest="snooze",
         type=int,
         default=1,
-        help="The duration, in months, to suppress reporting VTs after, based"
+        help="The duration, in months, to suppress reporting VTs after, based "
         "on the date stated in the solution text.",
     )
 


### PR DESCRIPTION
**What**:

As seen in the output below `newerthan` and `basedon` had missing spaces. There also was a `provived` typo.

Note: No new release required, could be included in some upcoming release.

```
$ troubadix-no-solution -h
usage: troubadix-no-solution [-h] [-d DIRECTORY] [-m MILESTONES [MILESTONES ...]] [-t THRESHOLD] [-s SNOOZE]

Check VTs for solution type 'NoneAvailable'

options:
  -h, --help            show this help message and exit
  -d DIRECTORY, --directory DIRECTORY
                        Specify the directory to scan for nasl scripts
  -m MILESTONES [MILESTONES ...], --milestones MILESTONES [MILESTONES ...]
                        Defines the milestones for which to report VTs without a solution for, in months. VTs with no solution newerthan the smallest milestone will not be reported.
  -t THRESHOLD, --threshold THRESHOLD
                        The threshold after which to assume no solution will be provived anymore
  -s SNOOZE, --snooze SNOOZE
                        The duration, in months, to suppress reporting VTs after, basedon the date stated in the solution text.
```

**Why**:

Not really necessary to describe...

**How**:

N/A

**Checklist**:

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation