### PR TITLE
Change: Only print the relative path of a found VT

### DIFF
--- a/troubadix/standalone_plugins/no_solution.py
+++ b/troubadix/standalone_plugins/no_solution.py
@@ -246,10 +246,9 @@ def print_report(
             )
 
         for vt, oid, solution, creation in vts:
-            term.info(vt.name)
+            term.info(str(vt.relative_to(root)))
 
             with term.indent():
-                term.print(f"File: {str(vt.relative_to(root))}")
                 term.print(f"OID: {oid}")
                 term.print(f"Created: {creation.strftime('%Y-%m-%d')}")
                 term.print(


### PR DESCRIPTION
**What**:

Shortens / deduplicates the output of reported VTs in the `no-solution` standalone by only printing the relative path instead of filename and relative path.

**Why**:

Closes: VTD-1895

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
