### PR TITLE
Add: Exclusion to http_links_in_tags plugin

### DIFF
--- a/tests/plugins/test_http_links_in_tags.py
+++ b/tests/plugins/test_http_links_in_tags.py
@@ -151,6 +151,7 @@ class CheckHttpLinksInTagsTestCase(PluginTestCase):
             "39. http://internal-host$1 is still insecure",
             "40. from online sources (ftp://, http:// etc.).",
             "41. this and https:// and that.",
+            "42. such as 'http://:80'",
         ]
 
         for testcase in testcases:

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -166,6 +166,7 @@ class CheckHttpLinksInTags(FilePlugin):
             "http://internal-host$1 is still insecure",
             "http:// ",
             "https:// ",
+            "such as 'http://:80'",
         ]
 
         return any(


### PR DESCRIPTION
**What**:
This PR adds an exclusion to the http_links_in_tags plugin.

**Why**:
To not raise a warning about https://www.debian.org/security/2015/dsa-3232.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
