### PR TITLE
Fix: Formatting and typo in help text

### DIFF
--- a/troubadix/standalone_plugins/changed_oid.py
+++ b/troubadix/standalone_plugins/changed_oid.py
@@ -53,9 +53,8 @@ def parse_args(args: Iterable[str]) -> Namespace:
         type=file_type,
         default=[],
         help=(
-            "List of files to diff."
-            "If empty use all files added or modifyed in the"
-            " commit range"
+            "List of files to diff. "
+            "If empty use all files added or modified in the commit range."
         ),
     )
     return parser.parse_args(args=args)

--- a/troubadix/standalone_plugins/version_updated.py
+++ b/troubadix/standalone_plugins/version_updated.py
@@ -66,9 +66,8 @@ def parse_args(args: Iterable[str]) -> Namespace:
         type=file_type,
         default=[],
         help=(
-            "List of files to diff."
-            "If empty use all files added or modifyed in the"
-            " commit range"
+            "List of files to diff. "
+            "If empty use all files added or modified in the commit range."
         ),
     )
     return parser.parse_args(args=args)


### PR DESCRIPTION
## What
This PR fixes the formatting and a typo in the help text of `troubadix-changed-oid` and `troubadix-version-updated`.

## Why
To have the typo fixed and a space between the sentences.

Before:
```
  -f FILES [FILES ...], --files FILES [FILES ...]
                        List of files to diff.If empty use all
                        files added or modifyed in the commit
                        range
```
After:
```
  -f FILES [FILES ...], --files FILES [FILES ...]
                        List of files to diff. If empty use all
                        files added or modified in the commit
                        range.
```

## References

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


