### PR TITLE
Add: changed-packages standalone plugin 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ troubadix-changed-oid = 'troubadix.standalone_plugins.changed_oid:main'
 troubadix-last-modification = 'troubadix.standalone_plugins.last_modification:main'
 troubadix-version-updated = 'troubadix.standalone_plugins.version_updated:main'
 troubadix-no-solution = 'troubadix.standalone_plugins.no_solution:main'
+troubadix-changed-packages = 'troubadix.standalone_plugins.changed_packages.changed_packages:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/standalone_plugins/changed_packages/__init__.py
+++ b/tests/standalone_plugins/changed_packages/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/standalone_plugins/changed_packages/markers/__init__.py
+++ b/tests/standalone_plugins/changed_packages/markers/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/standalone_plugins/changed_packages/markers/test_added_epoch.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_added_epoch.py
@@ -77,3 +77,23 @@ class AddedEpochTestCase(TestCase):
 
         self.assertEqual(expected_missing_packages, missing_packages)
         self.assertEqual(expected_new_packages, expected_new_packages)
+
+    def test_epoch_no_other_package(self):
+        missing_packages = [
+            Package("foo", "1.2.3", "DEB11"),
+        ]
+        new_packages = [
+            Package("foo", "1:4.5.6", "DEB11"),
+        ]
+
+        expected_missing_packages = [
+            Package("foo", "1.2.3", "DEB11"),
+        ]
+        expected_new_packages = [
+            Package("foo", "1:4.5.6", "DEB11"),
+        ]
+
+        AddedEpoch.mark(missing_packages, new_packages)
+
+        self.assertEqual(expected_missing_packages, missing_packages)
+        self.assertEqual(expected_new_packages, expected_new_packages)

--- a/tests/standalone_plugins/changed_packages/markers/test_added_epoch.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_added_epoch.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from troubadix.standalone_plugins.changed_packages.marker import AddedEpoch
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+
+class AddedEpochTestCase(TestCase):
+    def test_mark(self):
+        missing_packages = [
+            Package("foo", "1.2.3", "DEB11"),
+            Package("bar", "4.5-6", "DEB11"),
+            Package("baz", "1.3.3.7", "DEB11"),
+        ]
+        new_packages = [
+            Package("foo", "1:1.2.3", "DEB11"),
+            Package("bar", "4.5-6", "DEB11"),
+            Package("baz", "2:1.3.3.7", "DEB11"),
+        ]
+
+        expected_missing_packages = [
+            Package(
+                "foo",
+                "1.2.3",
+                "DEB11",
+                {Reasons.ADDED_EPOCH: Direction.PASSIVE},
+            ),
+            Package("bar", "4.5-6", "DEB11"),
+            Package(
+                "baz",
+                "1.3.3.7",
+                "DEB11",
+                {Reasons.ADDED_EPOCH: Direction.PASSIVE},
+            ),
+        ]
+        expected_new_packages = [
+            Package(
+                "foo",
+                "1:1.2.3",
+                "DEB11",
+                {Reasons.ADDED_EPOCH: Direction.ACTIVE},
+            ),
+            Package(
+                "bar",
+                "4.5-6",
+                "DEB11",
+            ),
+            Package(
+                "baz",
+                "2:1.3.3.7",
+                "DEB11",
+                {Reasons.ADDED_EPOCH: Direction.ACTIVE},
+            ),
+        ]
+
+        AddedEpoch.mark(missing_packages, new_packages)
+
+        self.assertEqual(expected_missing_packages, missing_packages)
+        self.assertEqual(expected_new_packages, expected_new_packages)

--- a/tests/standalone_plugins/changed_packages/markers/test_added_release.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_added_release.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from troubadix.standalone_plugins.changed_packages.marker import AddedRelease
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+
+class AddedReleaseTestCase(TestCase):
+    def test_mark(self):
+        old_packages = [
+            Package("foo", "1.2.3", "DEB10"),
+            Package("bar", "4.5-6", "DEB10"),
+            Package("baz", "1.3.3.7", "DEB10"),
+        ]
+        new_packages = [
+            Package("foo2", "1.2.3", "DEB11"),
+            Package("bar2", "4.5-6", "DEB11"),
+            Package("baz2", "1.3.3.7", "DEB10"),
+        ]
+
+        expected_new_packages = [
+            Package(
+                "foo2",
+                "1:1.2.3",
+                "DEB11",
+                {Reasons.ADDED_RELEASE: Direction.ACTIVE},
+            ),
+            Package(
+                "bar2",
+                "4.5-6",
+                "DEB11",
+                {Reasons.ADDED_RELEASE: Direction.ACTIVE},
+            ),
+            Package("baz2", "2:1.3.3.7", "DEB10"),
+        ]
+
+        AddedRelease.mark(old_packages, new_packages)
+
+        self.assertEqual(expected_new_packages, expected_new_packages)
+
+    def test_mark_not(self):
+        old_packages = [
+            Package("foo", "1.2.3", "DEB11"),
+            Package("bar", "4.5-6", "DEB10"),
+            Package("baz", "1.3.3.7", "DEB10"),
+        ]
+        new_packages = [
+            Package("foo2", "1.2.3", "DEB11"),
+            Package("bar2", "4.5-6", "DEB11"),
+            Package("baz2", "1.3.3.7", "DEB11"),
+        ]
+
+        expected_new_packages = [
+            Package("foo2", "1:1.2.3", "DEB11"),
+            Package("bar2", "4.5-6", "DEB11"),
+            Package("baz2", "2:1.3.3.7", "DEB11"),
+        ]
+
+        AddedRelease.mark(old_packages, new_packages)
+
+        self.assertEqual(expected_new_packages, expected_new_packages)

--- a/tests/standalone_plugins/changed_packages/markers/test_added_udeb.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_added_udeb.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from troubadix.standalone_plugins.changed_packages.marker import AddedUdeb
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+
+class AddedUdebTestCase(TestCase):
+    def test_mark(self):
+        new_packages = [
+            Package("foo", "1:1.2.3", "DEB11"),
+            Package("bar-udeb", "4.5-6", "DEB10"),
+            Package("baz-udeb", "2:1.3.3.7", "DEB11"),
+        ]
+
+        expected_new_packages = [
+            Package(
+                "foo",
+                "1:1.2.3",
+                "DEB11",
+                {Reasons.ADDED_UDEB: Direction.ACTIVE},
+            ),
+            Package(
+                "bar", "4.5-6", "DEB11", {Reasons.ADDED_UDEB: Direction.ACTIVE}
+            ),
+            Package(
+                "baz",
+                "2:1.3.3.7",
+                "DEB11",
+                {Reasons.ADDED_UDEB: Direction.ACTIVE},
+            ),
+        ]
+
+        AddedUdeb.mark(new_packages)
+
+        self.assertEqual(expected_new_packages, expected_new_packages)

--- a/tests/standalone_plugins/changed_packages/markers/test_changed_update.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_changed_update.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from troubadix.standalone_plugins.changed_packages.marker import ChangedUpdate
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+
+class ChangedUpdateTestCase(TestCase):
+    def test_mark(self):
+        missing_packages = [
+            Package("foo", "1.2.3", "DEB11"),
+            Package("bar", "4.5.6-deb11u1", "DEB11"),
+        ]
+        new_packages = [
+            Package("foo", "1.2.4", "DEB11"),
+            Package("bar", "4.5.6-deb11u2", "DEB11"),
+        ]
+
+        expected_missing_packages = [
+            Package(
+                "foo",
+                "1.2.3",
+                "DEB11",
+                {Reasons.CHANGED_UPDATE: Direction.ACTIVE},
+            ),
+            Package(
+                "bar",
+                "4.5.6-deb11u1",
+                "DEB11",
+                {Reasons.CHANGED_UPDATE: Direction.ACTIVE},
+            ),
+        ]
+        expected_new_packages = [
+            Package(
+                "foo",
+                "1.2.4",
+                "DEB11",
+                {Reasons.CHANGED_UPDATE: Direction.ACTIVE},
+            ),
+            Package(
+                "bar",
+                "4.5.6-deb11u2",
+                "DEB11",
+                {Reasons.CHANGED_UPDATE: Direction.ACTIVE},
+            ),
+        ]
+
+        ChangedUpdate.mark(missing_packages, new_packages)
+
+        self.assertEqual(expected_missing_packages, missing_packages)
+        self.assertEqual(expected_new_packages, new_packages)

--- a/tests/standalone_plugins/changed_packages/markers/test_changed_update.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_changed_update.py
@@ -69,3 +69,27 @@ class ChangedUpdateTestCase(TestCase):
 
         self.assertEqual(expected_missing_packages, missing_packages)
         self.assertEqual(expected_new_packages, new_packages)
+
+    def test_mark_no_match(self):
+        missing_packages = [Package("foo", "1.2.3a", "DEB11")]
+        new_packages = [Package("foo", "1.2.3a", "DEB11")]
+
+        expected_missing_packages = [Package("foo", "1.2.3a", "DEB11")]
+        expected_new_packages = [Package("foo", "1.2.3a", "DEB11")]
+
+        ChangedUpdate.mark(missing_packages, new_packages)
+
+        self.assertEqual(expected_missing_packages, missing_packages)
+        self.assertEqual(expected_new_packages, new_packages)
+
+    def test_mark_no_other_package(self):
+        missing_packages = [Package("foo", "1.2.3", "DEB11")]
+        new_packages = [Package("foo", "1.2.3-deb11u2", "DEB11")]
+
+        expected_missing_packages = [Package("foo", "1.2.3", "DEB11")]
+        expected_new_packages = [Package("foo", "1.2.3-deb11u2", "DEB11")]
+
+        ChangedUpdate.mark(missing_packages, new_packages)
+
+        self.assertEqual(expected_missing_packages, missing_packages)
+        self.assertEqual(expected_new_packages, new_packages)

--- a/tests/standalone_plugins/changed_packages/markers/test_dropped_architecture.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_dropped_architecture.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from troubadix.standalone_plugins.changed_packages.marker import (
+    DroppedArchitecture,
+)
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+
+class DroppedArchitectureTestCase(TestCase):
+    def test_mark(self):
+        missing_packages = [
+            Package("foo:amd64", "1.2.3", "DEB11"),
+            Package("foo:i386", "1.2.3", "DEB11"),
+            Package("bar:amd64", "4.5.6", "DEB11"),
+        ]
+        new_packages = [
+            Package("foo", "1.2.3", "DEB11"),
+            Package("bar", "4.5.6", "DEB11"),
+        ]
+
+        expected_missing_packages = [
+            Package(
+                "foo:amd64",
+                "1.2.3",
+                "DEB11",
+                {Reasons.DROPPED_ARCHITECTURE: Direction.PASSIVE},
+            ),
+            Package(
+                "foo:i386",
+                "1.2.3",
+                "DEB11",
+                {Reasons.DROPPED_ARCHITECTURE: Direction.PASSIVE},
+            ),
+            Package(
+                "bar:amd64",
+                "4.5.6",
+                "DEB11",
+                {Reasons.DROPPED_ARCHITECTURE: Direction.PASSIVE},
+            ),
+        ]
+        expected_new_packages = [
+            Package(
+                "foo",
+                "1.2.3",
+                "DEB11",
+                {Reasons.DROPPED_ARCHITECTURE: Direction.ACTIVE},
+            ),
+            Package(
+                "bar",
+                "4.5.6",
+                "DEB11",
+                {Reasons.DROPPED_ARCHITECTURE: Direction.ACTIVE},
+            ),
+        ]
+
+        DroppedArchitecture.mark(missing_packages, new_packages)
+
+        self.assertEqual(expected_missing_packages, missing_packages)
+        self.assertEqual(expected_new_packages, new_packages)

--- a/tests/standalone_plugins/changed_packages/markers/test_dropped_architecture.py
+++ b/tests/standalone_plugins/changed_packages/markers/test_dropped_architecture.py
@@ -78,3 +78,43 @@ class DroppedArchitectureTestCase(TestCase):
 
         self.assertEqual(expected_missing_packages, missing_packages)
         self.assertEqual(expected_new_packages, new_packages)
+
+    def test_mark_no_other_package(self):
+        missing_packages = [
+            Package("foo:amd64", "1.2.3", "DEB11"),
+            Package("foo:i386", "1.2.3", "DEB11"),
+            Package("bar", "4.5.6", "DEB11"),
+        ]
+        new_packages = [
+            Package("bar", "4.5.6", "DEB11"),
+        ]
+
+        expected_missing_packages = [
+            Package(
+                "foo:amd64",
+                "1.2.3",
+                "DEB11",
+            ),
+            Package(
+                "foo:i386",
+                "1.2.3",
+                "DEB11",
+            ),
+            Package(
+                "bar",
+                "4.5.6",
+                "DEB11",
+            ),
+        ]
+        expected_new_packages = [
+            Package(
+                "bar",
+                "4.5.6",
+                "DEB11",
+            ),
+        ]
+
+        DroppedArchitecture.mark(missing_packages, new_packages)
+
+        self.assertEqual(expected_missing_packages, missing_packages)
+        self.assertEqual(expected_new_packages, new_packages)

--- a/tests/standalone_plugins/changed_packages/test_changed_packages.py
+++ b/tests/standalone_plugins/changed_packages/test_changed_packages.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from troubadix.standalone_plugins.changed_packages.changed_packages import (
+    get_packages,
+)
+from troubadix.standalone_plugins.changed_packages.package import Package
+
+
+class ChangedPackagesTestCase(TestCase):
+    def test_get_package(self):
+        content = """
+        ...some NASL...
+        if(!isnull(res = isdpkgvuln(pkg:"libwpewebkit-1.0-3", ver:"2.38.3-1~deb11u1", rls:"DEB11"))) {
+            report += res;
+        }
+        if(!isnull(res = isdpkgvuln(pkg:"libwpewebkit-1.0-dev", ver:"2.38.3-1~deb11u1", rls:"DEB11"))) {
+            report += res;
+        }
+        if(!isnull(res = isdpkgvuln(pkg:"libwpewebkit-1.0-doc", ver:"2.38.3-1~deb11u1", rls:"DEB11"))) {
+            report += res;
+        }
+        if(!isnull(res = isdpkgvuln(pkg:"wpewebkit-driver", ver:"2.38.3-1~deb11u1", rls:"DEB11"))) {
+            report += res;
+        }
+        ...some more NASL...
+        """
+
+        result = get_packages(content)
+
+        expected_result = {
+            Package("libwpewebkit-1.0-3", "2.38.3-1~deb11u1", "DEB11"),
+            Package("libwpewebkit-1.0-dev", "2.38.3-1~deb11u1", "DEB11"),
+            Package("libwpewebkit-1.0-doc", "2.38.3-1~deb11u1", "DEB11"),
+            Package("wpewebkit-driver", "2.38.3-1~deb11u1", "DEB11"),
+        }
+
+        self.assertEqual(expected_result, result)
+
+    def test_get_package_duplicate(self):
+        content = """
+        ...some NASL...
+        if(!isnull(res = isdpkgvuln(pkg:"foo", ver:"1.2.3", rls:"DEB10"))) {
+            report += res;
+        }
+        if(!isnull(res = isdpkgvuln(pkg:"bar", ver:"1.2.3", rls:"DEB10"))) {
+            report += res;
+        }
+        if(!isnull(res = isdpkgvuln(pkg:"foo", ver:"1.2.3", rls:"DEB10"))) {
+            report += res;
+        }
+        ...some more NASL...
+        """
+
+        with self.assertRaises(Exception):
+            get_packages(content)

--- a/tests/standalone_plugins/changed_packages/test_changed_packages.py
+++ b/tests/standalone_plugins/changed_packages/test_changed_packages.py
@@ -18,9 +18,14 @@
 from unittest import TestCase
 
 from troubadix.standalone_plugins.changed_packages.changed_packages import (
+    filter_reasons,
     get_packages,
 )
-from troubadix.standalone_plugins.changed_packages.package import Package
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
 
 
 class ChangedPackagesTestCase(TestCase):
@@ -70,3 +75,41 @@ class ChangedPackagesTestCase(TestCase):
 
         with self.assertRaises(Exception):
             get_packages(content)
+
+    def test_filter_reasons(self):
+        packages = [
+            Package(
+                "foo", "1.2.3", "DEB11", {Reasons.ADDED_EPOCH: Direction.ACTIVE}
+            ),
+            Package(
+                "bar",
+                "1.2.3",
+                "DEB11",
+                {
+                    Reasons.ADDED_EPOCH: Direction.ACTIVE,
+                    Reasons.ADDED_RELEASE: Direction.PASSIVE,
+                },
+            ),
+            Package(
+                "baz", "1.2.3", "DEB11", {Reasons.ADDED_UDEB: Direction.ACTIVE}
+            ),
+        ]
+
+        expected_packages = [
+            Package(
+                "bar",
+                "1.2.3",
+                "DEB11",
+                {
+                    Reasons.ADDED_EPOCH: Direction.ACTIVE,
+                    Reasons.ADDED_RELEASE: Direction.PASSIVE,
+                },
+            ),
+            Package(
+                "baz", "1.2.3", "DEB11", {Reasons.ADDED_UDEB: Direction.ACTIVE}
+            ),
+        ]
+
+        result = filter_reasons(packages, [Reasons.ADDED_EPOCH])
+
+        self.assertEqual(expected_packages, result)

--- a/tests/standalone_plugins/changed_packages/test_package.py
+++ b/tests/standalone_plugins/changed_packages/test_package.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from argparse import ArgumentError
 from unittest import TestCase
 
 from troubadix.standalone_plugins.changed_packages.package import (
@@ -30,25 +31,36 @@ class ReasonsTextCase(TestCase):
             Reasons.from_cli_argument("dropped-architecture"),
         )
 
+    def test_from_cli_argument_not_okay(self):
+        with self.assertRaises(ArgumentError):
+            Reasons.from_cli_argument("foo")
+
+    def test_str(self):
+        self.assertEqual(str(Reasons.ADDED_EPOCH), "added-epoch")
+
 
 class PackageTestCase(TestCase):
-    def test_lt(self):
+    def test_lt_by_name(self):
         package = Package("a-foo", "1.2.3", "DEB11")
         other_package = Package("b-foo", "1.2.3", "DEB11")
 
         self.assertLess(package, other_package)
 
+    def test_lt_by_version(self):
         package = Package("foo", "1.2.3", "DEB11")
         other_package = Package("foo", "2.2.3", "DEB11")
 
-        print(
-            (package.release, package.name, package.version)
-            < (other_package.release, other_package.name, other_package.version)
-        )
-
         self.assertLess(package, other_package)
 
+    def test_lt_by_release(self):
         package = Package("foo", "1.2.3", "DEB10")
         other_package = Package("foo", "1.2.3", "DEB11")
 
         self.assertLess(package, other_package)
+
+    def test_lt_nothing_in_common(self):
+        package = Package("foo", "1.2.3", "DEB10")
+        other_package = Package("foo", "1.2.3", "DEB10")
+
+        self.assertFalse(package < other_package)
+        self.assertFalse(package > other_package)

--- a/tests/standalone_plugins/changed_packages/test_package.py
+++ b/tests/standalone_plugins/changed_packages/test_package.py
@@ -64,3 +64,10 @@ class PackageTestCase(TestCase):
 
         self.assertFalse(package < other_package)
         self.assertFalse(package > other_package)
+
+    def test_lt_release_first(self):
+        package = Package("b", "1.2.3", "DEB10")
+        other_package = Package("a", "1.2.3", "DEB11")
+
+        self.assertLess(package, other_package)
+        self.assertFalse(other_package < package)

--- a/tests/standalone_plugins/changed_packages/test_package.py
+++ b/tests/standalone_plugins/changed_packages/test_package.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from troubadix.standalone_plugins.changed_packages.package import (
+    Package,
+    Reasons,
+)
+
+
+class ReasonsTextCase(TestCase):
+    def test_from_cli_argument(self):
+        self.assertEqual(
+            Reasons.DROPPED_ARCHITECTURE,
+            Reasons.from_cli_argument("dropped-architecture"),
+        )
+
+
+class PackageTestCase(TestCase):
+    def test_lt(self):
+        package = Package("a-foo", "1.2.3", "DEB11")
+        other_package = Package("b-foo", "1.2.3", "DEB11")
+
+        self.assertLess(package, other_package)
+
+        package = Package("foo", "1.2.3", "DEB11")
+        other_package = Package("foo", "2.2.3", "DEB11")
+
+        print(
+            (package.release, package.name, package.version)
+            < (other_package.release, other_package.name, other_package.version)
+        )
+
+        self.assertLess(package, other_package)
+
+        package = Package("foo", "1.2.3", "DEB10")
+        other_package = Package("foo", "1.2.3", "DEB11")
+
+        self.assertLess(package, other_package)

--- a/troubadix/standalone_plugins/changed_oid.py
+++ b/troubadix/standalone_plugins/changed_oid.py
@@ -23,6 +23,8 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import Iterable
 
+from troubadix.standalone_plugins.common import git
+
 
 def file_type(string: str) -> Path:
     file_path = Path(string)
@@ -58,16 +60,6 @@ def parse_args(args: Iterable[str]) -> Namespace:
         ),
     )
     return parser.parse_args(args=args)
-
-
-def git(*args) -> str:
-    # git diff output uses raw bytes
-    return subprocess.run(
-        ["git"] + list(args),
-        capture_output=True,
-        encoding="latin-1",
-        check=True,
-    ).stdout
 
 
 def check_oid(args: Namespace) -> bool:

--- a/troubadix/standalone_plugins/changed_packages/changed_packages.py
+++ b/troubadix/standalone_plugins/changed_packages/changed_packages.py
@@ -21,7 +21,7 @@ import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Iterable
+from typing import Iterable, List
 
 from pontos.terminal.terminal import ConsoleTerminal
 
@@ -61,7 +61,7 @@ def compare(old_content: str, content: str):
     return missing_packages, new_packages
 
 
-def filter_reasons(packages: list[Package], reasons: Iterable[Reasons]):
+def filter_reasons(packages: List[Package], reasons: Iterable[Reasons]):
     return [
         package
         for package in packages
@@ -71,8 +71,8 @@ def filter_reasons(packages: list[Package], reasons: Iterable[Reasons]):
 
 
 def print_results(
-    missing_packages: list[Package],
-    new_packages: list[Package],
+    missing_packages: List[Package],
+    new_packages: List[Package],
     file: Path,
     terminal: ConsoleTerminal,
 ):
@@ -88,7 +88,7 @@ def print_results(
 
 
 def print_packages(
-    packages: list[Package],
+    packages: List[Package],
     terminal: ConsoleTerminal,
 ):
     with terminal.indent():

--- a/troubadix/standalone_plugins/changed_packages/changed_packages.py
+++ b/troubadix/standalone_plugins/changed_packages/changed_packages.py
@@ -127,11 +127,7 @@ def parse_args() -> Namespace:
         type=file_type,
         default=[],
         required=True,
-        help=(
-            "List of files to diff."
-            "If empty use all files added or modifyed in the"
-            " commit range"
-        ),
+        help="List of files to check.",
     )
     parser.add_argument(
         "--start-commit",

--- a/troubadix/standalone_plugins/changed_packages/changed_packages.py
+++ b/troubadix/standalone_plugins/changed_packages/changed_packages.py
@@ -1,0 +1,205 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import re
+import sys
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import Iterable
+
+from pontos.terminal.terminal import ConsoleTerminal
+
+from troubadix.argparser import file_type
+from troubadix.standalone_plugins.changed_packages.marker import (
+    AddedEpoch,
+    AddedRelease,
+    AddedUdeb,
+    ChangedUpdate,
+    DroppedArchitecture,
+)
+from troubadix.standalone_plugins.changed_packages.package import (
+    Package,
+    Reasons,
+)
+from troubadix.standalone_plugins.common import git
+
+PACKAGE_CHECK_PATTERN = re.compile(
+    r'isdpkgvuln\(pkg:"(?P<package>[^"]+)", ver:"(?P<version>[^"]+)", '
+    r'rls:"(?P<release>[^"]+)"\)'
+)
+
+
+def compare(old_content: str, content: str):
+    old_packages = get_packages(old_content)
+    packages = get_packages(content)
+
+    missing_packages = sorted(old_packages.difference(packages))
+    new_packages = sorted(packages.difference(old_packages))
+
+    AddedEpoch.mark(missing_packages, new_packages)
+    AddedRelease.mark(old_packages, new_packages)
+    AddedUdeb.mark(new_packages)
+    ChangedUpdate.mark(missing_packages, new_packages)
+    DroppedArchitecture.mark(missing_packages, new_packages)
+
+    return missing_packages, new_packages
+
+
+def filter_reasons(packages: list[Package], reasons: Iterable[Reasons]):
+    return [
+        package
+        for package in packages
+        if not package.reasons
+        or any([reason not in reasons for reason in package.reasons])
+    ]
+
+
+def print_results(
+    missing_packages: list[Package],
+    new_packages: list[Package],
+    file: Path,
+    terminal: ConsoleTerminal,
+):
+    terminal.warning(f"Packages for {file} differ")
+
+    if missing_packages:
+        terminal.print("Missing packages")
+        print_packages(missing_packages, terminal)
+
+    if new_packages:
+        terminal.print("New packages")
+        print_packages(new_packages, terminal)
+
+
+def print_packages(
+    packages: list[Package],
+    terminal: ConsoleTerminal,
+):
+    with terminal.indent():
+        for package in packages:
+            terminal.print(f"{package}")
+
+
+def get_packages(content: str):
+    package_checks = PACKAGE_CHECK_PATTERN.findall(content)
+    result = set(
+        [
+            Package(name=name, version=version, release=release)
+            for name, version, release in package_checks
+        ]
+    )
+
+    if len(result) != len(package_checks):
+        raise Exception(
+            "There are duplicate checks in the file. Cannot compare."
+        )
+
+    return result
+
+
+def get_merge_base():
+    return git("merge-base", "main", "HEAD").strip()
+
+
+def parse_args() -> Namespace:
+    parser = ArgumentParser(
+        description="Check for changed packages in dpkg-based LSCs",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        type=file_type,
+        default=[],
+        required=True,
+        help=(
+            "List of files to diff."
+            "If empty use all files added or modifyed in the"
+            " commit range"
+        ),
+    )
+    parser.add_argument(
+        "--start-commit",
+        type=str,
+        required=False,
+        help=(
+            "The commit before the changes to check have been introduced. "
+            "If the files have been renamed before, choose that commit. "
+            "Defaults to the merge-base with main"
+        ),
+        default=get_merge_base(),
+    )
+    parser.add_argument(
+        "--hide-equal",
+        action="store_true",
+        help="Omit log message, if a file has equal checks",
+    )
+    parser.add_argument(
+        "--hide-reasons",
+        nargs="*",
+        action="extend",
+        default=[],
+        type=Reasons.from_cli_argument,
+        choices=list(Reasons),
+        help="Disable the output for packages that changed for a given reason",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    hide_reasons = set(args.hide_reasons)
+    terminal = ConsoleTerminal()
+
+    terminal.info(
+        f"Checking {len(args.files)} file(s) from {args.start_commit} to HEAD"
+    )
+
+    for file in args.files:
+        try:
+            old_content = git("show", f"{args.start_commit}:{file}")
+        except CalledProcessError:
+            terminal.error(f"Could not find {file} at {args.start_commit}. ")
+            sys.exit(1)
+
+        content = git("show", f"HEAD:{file}")
+        missing_packages, new_packages = compare(old_content, content)
+
+        if not missing_packages and not new_packages:
+            if not args.hide_equal:
+                terminal.info(f"{file} has equal checks")
+            continue
+
+        missing_packages = filter_reasons(missing_packages, hide_reasons)
+        new_packages = filter_reasons(new_packages, hide_reasons)
+
+        if not missing_packages and not new_packages and hide_reasons:
+            terminal.info(f"Packages for {file} differ, but reasons are hidden")
+            continue
+
+        print_results(
+            missing_packages,
+            new_packages,
+            file,
+            terminal,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/troubadix/standalone_plugins/changed_packages/changed_packages.py
+++ b/troubadix/standalone_plugins/changed_packages/changed_packages.py
@@ -98,12 +98,10 @@ def print_packages(
 
 def get_packages(content: str):
     package_checks = PACKAGE_CHECK_PATTERN.findall(content)
-    result = set(
-        [
-            Package(name=name, version=version, release=release)
-            for name, version, release in package_checks
-        ]
-    )
+    result = {
+        Package(name=name, version=version, release=release)
+        for name, version, release in package_checks
+    }
 
     if len(result) != len(package_checks):
         raise Exception(

--- a/troubadix/standalone_plugins/changed_packages/marker/__init__.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .added_epoch import AddedEpoch
+from .added_release import AddedRelease
+from .added_udeb import AddedUdeb
+from .changed_update import ChangedUpdate
+from .dropped_architecture import DroppedArchitecture

--- a/troubadix/standalone_plugins/changed_packages/marker/added_epoch.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/added_epoch.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+from typing import List
 
 from troubadix.standalone_plugins.changed_packages.marker.marker import Marker
 from troubadix.standalone_plugins.changed_packages.package import (
@@ -29,7 +30,7 @@ PACKAGE_EPOCH_PATTERN = re.compile(r"^(?P<epoch>\d+):")
 
 class AddedEpoch(Marker):
     @classmethod
-    def mark(cls, missing_packages: list[Package], new_packages: list[Package]):
+    def mark(cls, missing_packages: List[Package], new_packages: List[Package]):
         for package in new_packages:
             match = PACKAGE_EPOCH_PATTERN.search(package.version)
             if not match:

--- a/troubadix/standalone_plugins/changed_packages/marker/added_epoch.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/added_epoch.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from troubadix.standalone_plugins.changed_packages.marker.marker import Marker
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+PACKAGE_EPOCH_PATTERN = re.compile(r"^(?P<epoch>\d+):")
+
+
+class AddedEpoch(Marker):
+    @classmethod
+    def mark(cls, missing_packages: list[Package], new_packages: list[Package]):
+        for package in new_packages:
+            match = PACKAGE_EPOCH_PATTERN.search(package.version)
+            if not match:
+                continue
+
+            epoch = match.group("epoch")
+            other_package = cls._find_package(
+                Package(
+                    package.name,
+                    package.version.removeprefix(epoch + ":"),
+                    package.release,
+                ),
+                missing_packages,
+            )
+
+            if not other_package:
+                continue
+
+            package.reasons[Reasons.ADDED_EPOCH] = Direction.ACTIVE
+            other_package.reasons[Reasons.ADDED_EPOCH] = Direction.PASSIVE

--- a/troubadix/standalone_plugins/changed_packages/marker/added_epoch.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/added_epoch.py
@@ -40,7 +40,7 @@ class AddedEpoch(Marker):
             other_package = cls._find_package(
                 Package(
                     package.name,
-                    package.version.removeprefix(epoch + ":"),
+                    package.version.replace(epoch + ":", ""),
                     package.release,
                 ),
                 missing_packages,

--- a/troubadix/standalone_plugins/changed_packages/marker/added_release.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/added_release.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from troubadix.standalone_plugins.changed_packages.package import (
     Direction,
     Package,
@@ -26,7 +28,7 @@ from .marker import Marker
 
 class AddedRelease(Marker):
     @staticmethod
-    def mark(old_packages: list[Package], new_packages: list[Package]):
+    def mark(old_packages: List[Package], new_packages: List[Package]):
         # Example: ...2015/debian/deb_3257.nasl now has DEB8 next to DEB7
         new_releases = set([package.release for package in new_packages])
         old_releases = set([package.release for package in old_packages])

--- a/troubadix/standalone_plugins/changed_packages/marker/added_release.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/added_release.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+from .marker import Marker
+
+
+class AddedRelease(Marker):
+    @staticmethod
+    def mark(old_packages: list[Package], new_packages: list[Package]):
+        # Example: ...2015/debian/deb_3257.nasl now has DEB8 next to DEB7
+        new_releases = set([package.release for package in new_packages])
+        old_releases = set([package.release for package in old_packages])
+
+        for new_release in new_releases.difference(old_releases):
+            for package in new_packages:
+                if package.release != new_release:
+                    continue
+
+                package.reasons[Reasons.ADDED_RELEASE] = Direction.ACTIVE

--- a/troubadix/standalone_plugins/changed_packages/marker/added_udeb.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/added_udeb.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+from .marker import Marker
+
+
+class AddedUdeb(Marker):
+    @staticmethod
+    def mark(new_packages: list[Package]):
+        for package in new_packages:
+            if package.name.endswith("-udeb"):
+                package.reasons[Reasons.ADDED_UDEB] = Direction.ACTIVE

--- a/troubadix/standalone_plugins/changed_packages/marker/added_udeb.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/added_udeb.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from troubadix.standalone_plugins.changed_packages.package import (
     Direction,
     Package,
@@ -26,7 +28,7 @@ from .marker import Marker
 
 class AddedUdeb(Marker):
     @staticmethod
-    def mark(new_packages: list[Package]):
+    def mark(new_packages: List[Package]):
         for package in new_packages:
             if package.name.endswith("-udeb"):
                 package.reasons[Reasons.ADDED_UDEB] = Direction.ACTIVE

--- a/troubadix/standalone_plugins/changed_packages/marker/changed_update.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/changed_update.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+from typing import List
 
 from troubadix.standalone_plugins.changed_packages.package import (
     Direction,
@@ -30,7 +31,7 @@ PACKAGE_UPDATE_SUFFIX_PATTERN = re.compile(r"(?P<update>\d+)$")
 
 class ChangedUpdate(Marker):
     @classmethod
-    def mark(cls, missing_packages: list[Package], new_packages: list[Package]):
+    def mark(cls, missing_packages: List[Package], new_packages: List[Package]):
         for package in new_packages:
             match = PACKAGE_UPDATE_SUFFIX_PATTERN.search(package.version)
             if not match:

--- a/troubadix/standalone_plugins/changed_packages/marker/changed_update.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/changed_update.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+from .marker import Marker
+
+PACKAGE_UPDATE_SUFFIX_PATTERN = re.compile(r"(?P<update>\d+)$")
+
+
+class ChangedUpdate(Marker):
+    @classmethod
+    def mark(cls, missing_packages: list[Package], new_packages: list[Package]):
+        for package in new_packages:
+            match = PACKAGE_UPDATE_SUFFIX_PATTERN.search(package.version)
+            if not match:
+                continue
+
+            suffix = match.group("update")
+            other_package = next(
+                (
+                    old_package
+                    for old_package in missing_packages
+                    if package.name == old_package.name
+                    and old_package.version.startswith(
+                        package.version.removesuffix(suffix)
+                    )
+                    and package.release == old_package.release
+                ),
+                None,
+            )
+
+            if not other_package:
+                continue
+
+            package.reasons[Reasons.CHANGED_UPDATE] = Direction.ACTIVE
+            other_package.reasons[Reasons.CHANGED_UPDATE] = Direction.ACTIVE

--- a/troubadix/standalone_plugins/changed_packages/marker/changed_update.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/changed_update.py
@@ -44,7 +44,7 @@ class ChangedUpdate(Marker):
                     for old_package in missing_packages
                     if package.name == old_package.name
                     and old_package.version.startswith(
-                        package.version.removesuffix(suffix)
+                        package.version.replace(suffix, "")
                     )
                     and package.release == old_package.release
                 ),

--- a/troubadix/standalone_plugins/changed_packages/marker/dropped_architecture.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/dropped_architecture.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from troubadix.standalone_plugins.changed_packages.package import (
+    Direction,
+    Package,
+    Reasons,
+)
+
+from .marker import Marker
+
+
+class DroppedArchitecture(Marker):
+    @classmethod
+    def mark(cls, missing_packages: list[Package], new_packages: list[Package]):
+        for package in missing_packages:
+            other_package = cls._find_package(
+                Package(
+                    package.name.split(":")[0],
+                    package.version,
+                    package.release,
+                ),
+                new_packages,
+            )
+
+            if not other_package:
+                continue
+
+            package.reasons[Reasons.DROPPED_ARCHITECTURE] = Direction.PASSIVE
+            other_package.reasons[
+                Reasons.DROPPED_ARCHITECTURE
+            ] = Direction.ACTIVE

--- a/troubadix/standalone_plugins/changed_packages/marker/dropped_architecture.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/dropped_architecture.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from troubadix.standalone_plugins.changed_packages.package import (
     Direction,
     Package,
@@ -26,7 +28,7 @@ from .marker import Marker
 
 class DroppedArchitecture(Marker):
     @classmethod
-    def mark(cls, missing_packages: list[Package], new_packages: list[Package]):
+    def mark(cls, missing_packages: List[Package], new_packages: List[Package]):
         for package in missing_packages:
             other_package = cls._find_package(
                 Package(

--- a/troubadix/standalone_plugins/changed_packages/marker/dropped_architecture.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/dropped_architecture.py
@@ -30,6 +30,9 @@ class DroppedArchitecture(Marker):
     @classmethod
     def mark(cls, missing_packages: List[Package], new_packages: List[Package]):
         for package in missing_packages:
+            if not ":" in package.name:
+                continue
+
             other_package = cls._find_package(
                 Package(
                     package.name.split(":")[0],

--- a/troubadix/standalone_plugins/changed_packages/marker/marker.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/marker.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Iterable
+
+from troubadix.standalone_plugins.changed_packages.package import Package
+
+
+class Marker:
+    @staticmethod
+    def _find_package(needle: Package, haystack: Iterable[Package]):
+        result = next(
+            (package for package in haystack if package == needle), None
+        )
+        return result

--- a/troubadix/standalone_plugins/changed_packages/marker/marker.py
+++ b/troubadix/standalone_plugins/changed_packages/marker/marker.py
@@ -22,8 +22,15 @@ from troubadix.standalone_plugins.changed_packages.package import Package
 
 class Marker:
     @staticmethod
-    def _find_package(needle: Package, haystack: Iterable[Package]):
+    def _find_package(package: Package, packages: Iterable[Package]):
         result = next(
-            (package for package in haystack if package == needle), None
+            (
+                other_package
+                for other_package in packages
+                if other_package.name == package.name
+                and other_package.version == package.version
+                and other_package.release == package.release
+            ),
+            None,
         )
         return result

--- a/troubadix/standalone_plugins/changed_packages/package.py
+++ b/troubadix/standalone_plugins/changed_packages/package.py
@@ -67,11 +67,14 @@ class Package:
 
     def __lt__(self, other: "Package") -> bool:
         # Sort by release first, then the other fields
-        return (self.release, self.name, other.version) < (
-            other.release,
-            other.name,
-            other.version,
-        )
+        if self.release != other.release:
+            return self.release < other.release
+        if self.name != other.name:
+            return self.name < other.name
+        if self.version != other.version:
+            return self.version < other.version
+
+        return False
 
     def __str__(self) -> str:
         result = f"{self.name : <50} {self.version : <40} {self.release : <10}"

--- a/troubadix/standalone_plugins/changed_packages/package.py
+++ b/troubadix/standalone_plugins/changed_packages/package.py
@@ -19,6 +19,7 @@
 from argparse import ArgumentError
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Dict
 
 
 class Direction(Enum):
@@ -51,7 +52,7 @@ class Package:
     name: str
     version: str
     release: str
-    reasons: dict[Reasons, Direction] = field(default_factory=dict)
+    reasons: Dict[Reasons, Direction] = field(default_factory=dict)
 
     def __hash__(self) -> int:
         return hash((self.name, self.version, self.release))

--- a/troubadix/standalone_plugins/changed_packages/package.py
+++ b/troubadix/standalone_plugins/changed_packages/package.py
@@ -80,11 +80,9 @@ class Package:
         result = f"{self.name : <50} {self.version : <40} {self.release : <10}"
 
         reasons = ", ".join(
-            [
-                f"{change}"
-                f"{' in new package' if direction == Direction.PASSIVE else ''}"
-                for change, direction in self.reasons.items()
-            ]
+            f"{change}"
+            f"{' in new package' if direction == Direction.PASSIVE else ''}"
+            for change, direction in self.reasons.items()
         )
         result += f"{reasons : <10}"
 

--- a/troubadix/standalone_plugins/changed_packages/package.py
+++ b/troubadix/standalone_plugins/changed_packages/package.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from argparse import ArgumentError
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Direction(Enum):
+    ACTIVE = 1
+    PASSIVE = 2
+
+
+class Reasons(str, Enum):
+    DROPPED_ARCHITECTURE = "Dropped architecture"
+    ADDED_EPOCH = "Added epoch"
+    CHANGED_UPDATE = "Changed update"
+    ADDED_UDEB = "Added udeb package"
+    ADDED_RELEASE = "Added a new release"
+
+    def __str__(self) -> str:
+        return self.name.lower().replace("_", "-")
+
+    @classmethod
+    def from_cli_argument(cls, cli_argument: str):
+        try:
+            return cls[cli_argument.upper().replace("-", "_")]
+        except KeyError as error:
+            raise ArgumentError(
+                None, f"Invalid reason '{cli_argument}'"
+            ) from error
+
+
+@dataclass()
+class Package:
+    name: str
+    version: str
+    release: str
+    reasons: dict[Reasons, Direction] = field(default_factory=dict)
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.version, self.release))
+
+    def __eq__(self, other: "Package") -> bool:
+        return (
+            self.name == other.name
+            and self.version == other.version
+            and self.release == other.release
+        )
+
+    def __lt__(self, other: "Package") -> bool:
+        # Sort by release first, then the other fields
+        return (self.release, self.name, other.version) < (
+            other.release,
+            other.name,
+            other.version,
+        )
+
+    def __str__(self) -> str:
+        result = f"{self.name : <50} {self.version : <40} {self.release : <10}"
+
+        reasons = ", ".join(
+            [
+                f"{change}"
+                f"{' in new package' if direction == Direction.PASSIVE else ''}"
+                for change, direction in self.reasons.items()
+            ]
+        )
+        result += f"{reasons : <10}"
+
+        return result

--- a/troubadix/standalone_plugins/changed_packages/package.py
+++ b/troubadix/standalone_plugins/changed_packages/package.py
@@ -61,6 +61,7 @@ class Package:
             self.name == other.name
             and self.version == other.version
             and self.release == other.release
+            and self.reasons == other.reasons
         )
 
     def __lt__(self, other: "Package") -> bool:

--- a/troubadix/standalone_plugins/common.py
+++ b/troubadix/standalone_plugins/common.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+
+def git(*args) -> str:
+    # git diff output uses raw bytes
+    return subprocess.run(
+        ["git"] + list(args),
+        capture_output=True,
+        encoding="latin-1",
+        check=True,
+    ).stdout

--- a/troubadix/standalone_plugins/version_updated.py
+++ b/troubadix/standalone_plugins/version_updated.py
@@ -27,6 +27,7 @@ from troubadix.helper.patterns import (
     LAST_MODIFICATION_ANY_VALUE_PATTERN,
     SCRIPT_VERSION_ANY_VALUE_PATTERN,
 )
+from troubadix.standalone_plugins.common import git
 
 SCRIPT_VERSION_PATTERN = re.compile(
     r"^\+\s*" + SCRIPT_VERSION_ANY_VALUE_PATTERN, re.MULTILINE
@@ -71,16 +72,6 @@ def parse_args(args: Iterable[str]) -> Namespace:
         ),
     )
     return parser.parse_args(args=args)
-
-
-def git(*args) -> str:
-    # git diff output uses raw bytes
-    return subprocess.run(
-        ["git"] + list(args),
-        capture_output=True,
-        encoding="latin-1",
-        check=True,
-    ).stdout
 
 
 def check_version_updated(files: List[Path], commit_range: str) -> bool:


### PR DESCRIPTION
## What
This PR adds `changed-packages` as a standalone plugin to Troubadix.

## Why
To give NASL developers to review large PRs easier and quickly check the changed packages.

## References

VTA-397

## Checklist

- [x] Tests


