### PR TITLE
Add: changed-cves standalone plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ troubadix-last-modification = 'troubadix.standalone_plugins.last_modification:ma
 troubadix-version-updated = 'troubadix.standalone_plugins.version_updated:main'
 troubadix-no-solution = 'troubadix.standalone_plugins.no_solution:main'
 troubadix-changed-packages = 'troubadix.standalone_plugins.changed_packages.changed_packages:main'
+troubadix-changed-cves = 'troubadix.standalone_plugins.changed_cves:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/standalone_plugins/test_changed_cves.py
+++ b/tests/standalone_plugins/test_changed_cves.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from troubadix.standalone_plugins.changed_cves import (
+    compare,
+    get_cves_from_content,
+)
+
+
+class ChangedCVEsTest(TestCase):
+    def test_get_cves_from_content(self):
+        content = (
+            "...\n"
+            'script_oid("1.3.6.1.4.1.25623.1.0.705311");\n'
+            'script_version("2023-01-10T10:12:01+0000");\n'
+            'script_cve_id("CVE-2022-32749", "CVE-2022-37392");\n'
+            'script_tag(name:"cvss_base", value:"5.0");\n'
+            "..."
+        )
+
+        expected_result = {"CVE-2022-32749", "CVE-2022-37392"}
+
+        result = get_cves_from_content(content)
+
+        self.assertEqual(expected_result, result)
+
+    def test_get_cves_from_content_empty(self):
+        content = (
+            "...\n"
+            'script_oid("1.3.6.1.4.1.25623.1.0.705311");\n'
+            'script_version("2023-01-10T10:12:01+0000");\n'
+            'script_tag(name:"cvss_base", value:"5.0");\n'
+            "..."
+        )
+
+        expected_result = set()
+
+        result = get_cves_from_content(content)
+
+        self.assertEqual(expected_result, result)
+
+    @patch("troubadix.standalone_plugins.changed_cves.get_cves_from_content")
+    def test_compare(self, mock):
+        mock.side_effect = [
+            {"CVE-3333-3333", "CVE-2222-2222", "CVE-1111-1111"},
+            {"CVE-1111-1111", "CVE-4444-4444"},
+        ]
+
+        expected_missing_cves = ["CVE-2222-2222", "CVE-3333-3333"]
+        expected_new_cves = ["CVE-4444-4444"]
+
+        missing_cves, new_cves = compare("", "")
+
+        self.assertEqual(expected_missing_cves, missing_cves)
+        self.assertEqual(expected_new_cves, new_cves)

--- a/tests/standalone_plugins/test_changed_cves.py
+++ b/tests/standalone_plugins/test_changed_cves.py
@@ -41,6 +41,23 @@ class ChangedCVEsTest(TestCase):
 
         self.assertEqual(expected_result, result)
 
+    def test_get_cves_from_content_multiline(self):
+        content = (
+            "...\n"
+            'script_oid("1.3.6.1.4.1.25623.1.0.705311");\n'
+            'script_version("2023-01-10T10:12:01+0000");\n'
+            'script_cve_id("CVE-2022-32749",\n'
+            '"CVE-2022-37392");\n'
+            'script_tag(name:"cvss_base", value:"5.0");\n'
+            "..."
+        )
+
+        expected_result = {"CVE-2022-32749", "CVE-2022-37392"}
+
+        result = get_cves_from_content(content)
+
+        self.assertEqual(expected_result, result)
+
     def test_get_cves_from_content_empty(self):
         content = (
             "...\n"

--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -255,7 +255,7 @@ def init_special_script_tag_patterns() -> None:
 
         if value is None:
             value = r".+?"
-            flags = re.MULTILINE | re.DOTALL
+            flags = re.MULTILINE
 
         __special_script_tag_patterns[tag] = _get_special_script_tag_pattern(
             name=tag.value, value=value, flags=flags

--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -255,7 +255,7 @@ def init_special_script_tag_patterns() -> None:
 
         if value is None:
             value = r".+?"
-            flags = re.MULTILINE
+            flags = re.MULTILINE | re.DOTALL
 
         __special_script_tag_patterns[tag] = _get_special_script_tag_pattern(
             name=tag.value, value=value, flags=flags

--- a/troubadix/standalone_plugins/changed_cves.py
+++ b/troubadix/standalone_plugins/changed_cves.py
@@ -9,9 +9,7 @@ from troubadix.helper.patterns import (
     SpecialScriptTag,
     get_special_script_tag_pattern,
 )
-from troubadix.standalone_plugins.common import get_merge_base
-
-from .changed_oid import git
+from troubadix.standalone_plugins.common import get_merge_base, git
 
 CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,7}")
 

--- a/troubadix/standalone_plugins/changed_cves.py
+++ b/troubadix/standalone_plugins/changed_cves.py
@@ -37,7 +37,7 @@ def get_cves_from_content(content: str) -> Set[str]:
 
 def parse_args() -> Namespace:
     parser = ArgumentParser(
-        description="Check for changed packages in dpkg-based LSCs",
+        description="Check for changed CVEs in VTs",
     )
     parser.add_argument(
         "--files",

--- a/troubadix/standalone_plugins/changed_cves.py
+++ b/troubadix/standalone_plugins/changed_cves.py
@@ -16,6 +16,16 @@ from .changed_oid import git
 CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,7}")
 
 
+def compare(old_content: str, content: str):
+    old_cves = get_cves_from_content(old_content)
+    cves = get_cves_from_content(content)
+
+    missing_cves = sorted(old_cves.difference(cves))
+    new_cves = sorted(cves.difference(old_cves))
+
+    return missing_cves, new_cves
+
+
 def get_cves_from_content(content: str):
     pattern = get_special_script_tag_pattern(SpecialScriptTag.CVE_ID)
     match = pattern.search(content)
@@ -76,16 +86,12 @@ def main():
             )
             continue
 
-        old_cves = get_cves_from_content(old_content)
-        cves = get_cves_from_content(content)
+        missing_cves, new_cves = compare(old_content, content)
 
-        if old_cves == cves:
+        if not missing_cves and not new_cves:
             if not args.hide_equal:
                 terminal.info(f"{file} has equal CVEs")
             continue
-
-        missing_cves = sorted(old_cves.difference(cves))
-        new_cves = sorted(cves.difference(old_cves))
 
         terminal.warning(f"CVEs for {file} differ")
         if missing_cves:

--- a/troubadix/standalone_plugins/changed_cves.py
+++ b/troubadix/standalone_plugins/changed_cves.py
@@ -12,7 +12,7 @@ from troubadix.helper.patterns import (
 )
 from troubadix.standalone_plugins.common import get_merge_base, git
 
-CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,7}")
+CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,}")
 
 
 def compare(old_content: str, content: str) -> Tuple[List[str], List[str]]:

--- a/troubadix/standalone_plugins/changed_cves.py
+++ b/troubadix/standalone_plugins/changed_cves.py
@@ -6,10 +6,7 @@ from typing import List, Set, Tuple
 from pontos.terminal.terminal import ConsoleTerminal
 
 from troubadix.argparser import file_type
-from troubadix.helper.patterns import (
-    SpecialScriptTag,
-    get_special_script_tag_pattern,
-)
+from troubadix.helper.patterns import _get_special_script_tag_pattern
 from troubadix.standalone_plugins.common import get_merge_base, git
 
 CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,}")
@@ -28,7 +25,9 @@ def compare(
 
 
 def get_cves_from_content(content: str) -> Set[str]:
-    pattern = get_special_script_tag_pattern(SpecialScriptTag.CVE_ID)
+    pattern = _get_special_script_tag_pattern(
+        name="cve_id", flags=re.MULTILINE | re.DOTALL
+    )
     match = pattern.search(content)
     if not match:
         return set()

--- a/troubadix/standalone_plugins/changed_cves.py
+++ b/troubadix/standalone_plugins/changed_cves.py
@@ -1,6 +1,7 @@
 import re
 from argparse import ArgumentParser, Namespace
 from subprocess import CalledProcessError
+from typing import List, Set, Tuple
 
 from pontos.terminal.terminal import ConsoleTerminal
 
@@ -14,7 +15,7 @@ from troubadix.standalone_plugins.common import get_merge_base, git
 CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,7}")
 
 
-def compare(old_content: str, content: str):
+def compare(old_content: str, content: str) -> Tuple[List[str], List[str]]:
     old_cves = get_cves_from_content(old_content)
     cves = get_cves_from_content(content)
 
@@ -24,7 +25,7 @@ def compare(old_content: str, content: str):
     return missing_cves, new_cves
 
 
-def get_cves_from_content(content: str):
+def get_cves_from_content(content: str) -> Set[str]:
     pattern = get_special_script_tag_pattern(SpecialScriptTag.CVE_ID)
     match = pattern.search(content)
     if not match:

--- a/troubadix/standalone_plugins/changed_cves.py
+++ b/troubadix/standalone_plugins/changed_cves.py
@@ -9,6 +9,7 @@ from troubadix.helper.patterns import (
     SpecialScriptTag,
     get_special_script_tag_pattern,
 )
+from troubadix.standalone_plugins.common import get_merge_base
 
 from .changed_oid import git
 
@@ -23,10 +24,6 @@ def get_cves_from_content(content: str):
 
     cves = CVE_PATTERN.findall(match.group("value"))
     return set(cves)
-
-
-def get_merge_base():
-    return git("merge-base", "main", "HEAD").strip()
 
 
 def parse_args() -> Namespace:
@@ -50,7 +47,7 @@ def parse_args() -> Namespace:
             "If the files have been renamed before, choose that commit. "
             "Defaults to the merge-base with main"
         ),
-        default=get_merge_base(),
+        default=get_merge_base("main", "HEAD"),
     )
     parser.add_argument(
         "--hide-equal",

--- a/troubadix/standalone_plugins/changed_packages/changed_packages.py
+++ b/troubadix/standalone_plugins/changed_packages/changed_packages.py
@@ -36,7 +36,7 @@ from troubadix.standalone_plugins.changed_packages.package import (
     Package,
     Reasons,
 )
-from troubadix.standalone_plugins.common import git
+from troubadix.standalone_plugins.common import get_merge_base, git
 
 PACKAGE_CHECK_PATTERN = re.compile(
     r'isdpkgvuln\(pkg:"(?P<package>[^"]+)", ver:"(?P<version>[^"]+)", '
@@ -108,10 +108,6 @@ def get_packages(content: str):
     return result
 
 
-def get_merge_base():
-    return git("merge-base", "main", "HEAD").strip()
-
-
 def parse_args() -> Namespace:
     parser = ArgumentParser(
         description="Check for changed packages in dpkg-based LSCs",
@@ -133,7 +129,7 @@ def parse_args() -> Namespace:
             "If the files have been renamed before, choose that commit. "
             "Defaults to the merge-base with main"
         ),
-        default=get_merge_base(),
+        default=get_merge_base("main", "HEAD"),
     )
     parser.add_argument(
         "--hide-equal",

--- a/troubadix/standalone_plugins/common.py
+++ b/troubadix/standalone_plugins/common.py
@@ -26,3 +26,7 @@ def git(*args) -> str:
         encoding="latin-1",
         check=True,
     ).stdout
+
+
+def get_merge_base(*commits: str):
+    return git("merge-base", *commits).strip()


### PR DESCRIPTION
## What
This PR adds `changed-cves` as a standalone plugin to Troubadix.

## Why
To give NASL developers to review large PRs easier and quickly check the changed CVEs.

Example:
```
troubadix-changed-cves --files nasl/common/2015/debian/*                                             
ℹ Checking 308 file(s) from 4c338f222994e186320664d121198d14b78fc8bd to HEAD                                                                                                    
ℹ nasl/common/2015/debian/deb_3118.nasl has equal CVEs                                                                                                                          
⚠ CVEs for nasl/common/2015/debian/deb_3119.nasl differ                                                                                                                         
  New CVEs: CVE-2015-6525                                                                                                                                                       
ℹ nasl/common/2015/debian/deb_3120.nasl has equal CVEs                                                                                                                          
⚠ CVEs for nasl/common/2015/debian/deb_3121.nasl differ                                                                                                                         
  New CVEs: CVE-2014-9652                                                                                                                                                       
ℹ nasl/common/2015/debian/deb_3122.nasl has equal CVEs                                                                                                                          
ℹ nasl/common/2015/debian/deb_3123.nasl has equal CVEs
[...]
```

## References
VTA-403

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


