### PR TITLE
Fix: Number of jobs must be 1 or higher

### DIFF
--- a/troubadix/argparser.py
+++ b/troubadix/argparser.py
@@ -216,7 +216,7 @@ def parse_args(
         "-j",
         "--n-jobs",
         dest="n_jobs",
-        default=cpu_count() // 2,
+        default=max(1, cpu_count() // 2),
         type=check_cpu_count,
         help=(
             "Define number of jobs, that should run simultaneously. "


### PR DESCRIPTION
## What
This PR fixes Troubadix to fail when a system only has one core.

## Why
To not crash, because you cannot run with `1 // 2`, so `0` jobs.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


