### PR TITLE
Add: Exclusion to http_links_in_tags plugin

### DIFF
--- a/tests/plugins/test_http_links_in_tags.py
+++ b/tests/plugins/test_http_links_in_tags.py
@@ -152,6 +152,7 @@ class CheckHttpLinksInTagsTestCase(PluginTestCase):
             "40. from online sources (ftp://, http:// etc.).",
             "41. this and https:// and that.",
             "42. such as 'http://:80'",
+            "43. <http://localhost/moodle/admin/>",
         ]
 
         for testcase in testcases:

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -166,6 +166,7 @@ class CheckHttpLinksInTags(FilePlugin):
             "http:// ",
             "https:// ",
             "such as 'http://:80'",
+            "<http://localhost/moodle/admin/>",
         ]
 
         return any(


### PR DESCRIPTION
## What
This PR adds an exclusion to the http_links_in_tags plugin.

## Why
To not raise a warning about https://github.com/greenbone/vulnerability-tests/actions/runs/4364631411/jobs/7632188595#step:11:92

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


