### PR TITLE
Change: Temporarily disable --hard-encoding-detection due to an issue in codespell 2.2.4

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -207,7 +207,8 @@ class CheckSpelling(FilesPlugin):
                 for nasl_file in self.context.nasl_files[i : i + batch_size]
             ]
             codespell_arguments = [
-                "--hard-encoding-detection",
+                # nb: Temporarily disabled due to an issue in codespell 2.2.4.
+                # "--hard-encoding-detection",
                 "--dictionary=-",
                 f"--dictionary={codespell_additions}",
                 f"--exclude-file={codespell_exclude}",


### PR DESCRIPTION
## What

- There is an issue when using `chardet` (internally used when `--hard-encoding-detection` is enabled) which got fixed recently via codespell-project/codespell#2785
- This PR disables the usage of `--hard-encoding-detection` until a new codespell containing the fix has been released

## Why

Current "full" runs of Troubadix against the whole feed are failing completely, this should make the runs pass again.

## References

- VTD-1940
- codespell-project/codespell#2785