### PR TITLE
Change: Update wording in copyright_year plugin. Adjust tests.

### DIFF
--- a/tests/plugins/test_copyright_year.py
+++ b/tests/plugins/test_copyright_year.py
@@ -112,7 +112,7 @@ class CheckCopyrightYearTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(
             "VT contains a Copyright year not matching "
-            "the year 2020 at line 2",
+            "the creation year 2020 at line 2",
             results[0].message,
         )
 
@@ -149,7 +149,7 @@ class CheckCopyrightYearTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(
             "VT contains a Copyright year not matching "
-            "the year 2022 at line 2",
+            "the creation year 2022 at line 2",
             results[0].message,
         )
 
@@ -169,7 +169,7 @@ class CheckCopyrightYearTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(
             "VT contains a Copyright year not matching "
-            "the year 2022 at line 1",
+            "the creation year 2022 at line 1",
             results[0].message,
         )
 
@@ -189,6 +189,6 @@ class CheckCopyrightYearTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(
             "VT contains a Copyright year not matching "
-            "the year 2022 at line 1",
+            "the creation year 2022 at line 1",
             results[0].message,
         )

--- a/troubadix/plugins/copyright_year.py
+++ b/troubadix/plugins/copyright_year.py
@@ -72,7 +72,7 @@ class CheckCopyrightYear(LineContentPlugin):
                     if copyright_year > creation_year:
                         yield LinterError(
                             "VT contains a Copyright year not matching "
-                            f"the year {creation_year} at line {nr}",
+                            f"the creation year {creation_year} at line {nr}",
                             file=nasl_file,
                             plugin=self.name,
                             line=nr,
@@ -80,7 +80,7 @@ class CheckCopyrightYear(LineContentPlugin):
                 else:
                     yield LinterError(
                         "VT contains a Copyright year not matching "
-                        f"the year {creation_year} at line {nr}",
+                        f"the creation year {creation_year} at line {nr}",
                         file=nasl_file,
                         plugin=self.name,
                         line=nr,


### PR DESCRIPTION
## What

Update the log message to include the `creation` word

Note: No dedicated release required, could be shipped with the next one.

## Why

Gives more context / background on the finding

## References

None

## Checklist

- [x] Tests


