### PR TITLE
Change: security_message check to scan for security_message calls

### DIFF
--- a/tests/plugins/test_security_messages.py
+++ b/tests/plugins/test_security_messages.py
@@ -90,7 +90,8 @@ class CheckSecurityMessagesTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT is using a security_message or implementing function in a VT without severity",
+            "VT is using a security_message or implementing"
+            " function in a VT without severity",
             results[0].message,
         )
 
@@ -114,6 +115,33 @@ class CheckSecurityMessagesTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT is using a security_message or implementing function in a VT without severity",
+            "VT is using a security_message or implementing "
+            "function in a VT without severity",
+            results[0].message,
+        )
+
+    def test_nok3(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            'script_tag(name:"cvss_base", value:"0.0");\n'
+            'script_tag(name:"summary", value:"Foo Bar.");\n'
+            'script_tag(name:"solution_type", value:"VendorFix");\n'
+            'script_tag(name:"solution", value:"meh");\n'
+            "security_message( port:port, data:'It was possible to get the "
+            "csrf token `' + token[1] + '` via a jsonp request to: ' + "
+            "http_report_vuln_url( port:port, url:url, url_only:TRUE ) );\n"
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckSecurityMessages(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "VT is using a security_message or implementing"
+            " function in a VT without severity",
             results[0].message,
         )

--- a/tests/plugins/test_security_messages.py
+++ b/tests/plugins/test_security_messages.py
@@ -90,7 +90,7 @@ class CheckSecurityMessagesTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT is using a security_message in a VT without severity",
+            "VT is using a security_message or implementing function in a VT without severity",
             results[0].message,
         )
 
@@ -114,6 +114,6 @@ class CheckSecurityMessagesTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT is using a security_message in a VT without severity",
+            "VT is using a security_message or implementing function in a VT without severity",
             results[0].message,
         )

--- a/troubadix/plugins/security_messages.py
+++ b/troubadix/plugins/security_messages.py
@@ -36,7 +36,8 @@ def _file_contains_security_message(file_content: str) -> bool:
         file_content (str): The content of the VT
     """
     return any(
-        sec_msg in file_content for sec_msg in security_message_implementations
+        security_message in file_content
+        for security_message in SECURITY_MESSAGE_IMPLEMENTATIONS
     )
 
 

--- a/troubadix/plugins/security_messages.py
+++ b/troubadix/plugins/security_messages.py
@@ -20,7 +20,7 @@ from typing import Iterator
 from troubadix.helper.patterns import ScriptTag, get_script_tag_pattern
 from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
 
-security_message_implementations = [
+SECURITY_MESSAGE_IMPLEMENTATIONS = [
     "security_message",
     "http_check_remote_code",
     "citrix_xenserver_check_report_is_vulnerable",

--- a/troubadix/plugins/security_messages.py
+++ b/troubadix/plugins/security_messages.py
@@ -29,6 +29,12 @@ security_message_implementations = [
 
 
 def _file_contains_security_message(file_content: str) -> bool:
+    """Checks wether a VT content contains a call to security_message
+    or any function known to implement it
+
+    Args:
+        file_content (str): The content of the VT
+    """
     return any(
         sec_msg in file_content for sec_msg in security_message_implementations
     )
@@ -39,7 +45,14 @@ class CheckSecurityMessages(FileContentPlugin):
 
     def _check_security_message_present(
         self, nasl_file: Path, file_content: str
-    ) -> LinterResult:
+    ) -> Iterator[LinterResult]:
+        """Checks that the VT does have a
+        security_message or implementing function call
+
+        Args:
+            nasl_file (Path): The VTs path
+            file_content (str): The content of the VT
+        """
         deprecated_pattern = get_script_tag_pattern(
             script_tag=ScriptTag.DEPRECATED
         )
@@ -56,7 +69,14 @@ class CheckSecurityMessages(FileContentPlugin):
 
     def _check_security_message_absent(
         self, nasl_file: Path, file_content: str
-    ) -> LinterResult:
+    ) -> Iterator[LinterResult]:
+        """Checks that the VT does not have a
+        security_message or implementing function call
+
+        Args:
+            nasl_file (Path): The VTs path
+            file_content (str): The content of the VT
+        """
         # Policy VTs might use both, security_message and log_message
         if (
             "Policy/" in str(nasl_file)
@@ -76,6 +96,13 @@ class CheckSecurityMessages(FileContentPlugin):
     def _determinate_security_message_by_severity(
         self, file_content: str
     ) -> bool:
+        """Determinates wether a VT requires a
+        security_message or implementing function
+        call
+
+        Args:
+            file_content (str): The content of the VT
+        """
         cvss_base_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)
         cvss_detect = cvss_base_pattern.search(file_content)
 
@@ -88,7 +115,7 @@ class CheckSecurityMessages(FileContentPlugin):
     ) -> Iterator[LinterResult]:
         """This script checks the passed VT if it is using a security_message
         and having no severity (CVSS score) assigned or has a severity assigned
-        but dies not call security_message or an implementing function
+        but does not call security_message or an implementing function
 
         Args:
             nasl_file: The VT that is going to be checked

--- a/troubadix/plugins/security_messages.py
+++ b/troubadix/plugins/security_messages.py
@@ -39,7 +39,7 @@ class CheckSecurityMessages(FileContentPlugin):
 
     def _check_security_message_present(
         self, nasl_file: Path, file_content: str
-    ) -> Iterator[LinterResult]:
+    ) -> LinterResult:
         deprecated_pattern = get_script_tag_pattern(
             script_tag=ScriptTag.DEPRECATED
         )
@@ -48,14 +48,15 @@ class CheckSecurityMessages(FileContentPlugin):
 
         if not _file_contains_security_message(file_content):
             yield LinterError(
-                "VT is missing a security_message or implementing function in a VT with severity",
+                "VT is missing a security_message or implementing"
+                " function in a VT with severity",
                 file=nasl_file,
                 plugin=self.name,
             )
 
     def _check_security_message_absent(
         self, nasl_file: Path, file_content: str
-    ) -> Iterator[LinterResult]:
+    ) -> LinterResult:
         # Policy VTs might use both, security_message and log_message
         if (
             "Policy/" in str(nasl_file)
@@ -66,7 +67,8 @@ class CheckSecurityMessages(FileContentPlugin):
 
         if _file_contains_security_message(file_content):
             yield LinterError(
-                "VT is using a security_message or implementing function in a VT without severity",
+                "VT is using a security_message or implementing"
+                " function in a VT without severity",
                 file=nasl_file,
                 plugin=self.name,
             )
@@ -101,6 +103,10 @@ class CheckSecurityMessages(FileContentPlugin):
         )
 
         if security_message_required:
-            return self._check_security_message_present(nasl_file, file_content)
+            yield from self._check_security_message_present(
+                nasl_file, file_content
+            )
         else:
-            return self._check_security_message_absent(nasl_file, file_content)
+            yield from self._check_security_message_absent(
+                nasl_file, file_content
+            )

--- a/troubadix/plugins/security_messages.py
+++ b/troubadix/plugins/security_messages.py
@@ -14,16 +14,70 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import re
 from pathlib import Path
 from typing import Iterator
 
 from troubadix.helper.patterns import ScriptTag, get_script_tag_pattern
 from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
 
+security_message_implementations = [
+    "security_message",
+    "http_check_remote_code",
+    "citrix_xenserver_check_report_is_vulnerable",
+    "citrix_xenserver_report_missing_patch",
+]
+
+
+def _file_contains_security_message(file_content: str) -> bool:
+    return any(
+        sec_msg in file_content for sec_msg in security_message_implementations
+    )
+
 
 class CheckSecurityMessages(FileContentPlugin):
     name = "check_security_messages"
+
+    def _check_security_message_present(
+        self, nasl_file: Path, file_content: str
+    ) -> Iterator[LinterResult]:
+        deprecated_pattern = get_script_tag_pattern(
+            script_tag=ScriptTag.DEPRECATED
+        )
+        if deprecated_pattern.match(file_content):
+            return
+
+        if not _file_contains_security_message(file_content):
+            yield LinterError(
+                "VT is missing a security_message or implementing function in a VT with severity",
+                file=nasl_file,
+                plugin=self.name,
+            )
+
+    def _check_security_message_absent(
+        self, nasl_file: Path, file_content: str
+    ) -> Iterator[LinterResult]:
+        # Policy VTs might use both, security_message and log_message
+        if (
+            "Policy/" in str(nasl_file)
+            or "PCIDSS/" in str(nasl_file)
+            or "GSHB/" in str(nasl_file)
+        ):
+            return
+
+        if _file_contains_security_message(file_content):
+            yield LinterError(
+                "VT is using a security_message or implementing function in a VT without severity",
+                file=nasl_file,
+                plugin=self.name,
+            )
+
+    def _determinate_security_message_by_severity(
+        self, file_content: str
+    ) -> bool:
+        cvss_base_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)
+        cvss_detect = cvss_base_pattern.search(file_content)
+
+        return cvss_detect and cvss_detect.group("value") != "0.0"
 
     def check_content(
         self,
@@ -31,8 +85,8 @@ class CheckSecurityMessages(FileContentPlugin):
         file_content: str,
     ) -> Iterator[LinterResult]:
         """This script checks the passed VT if it is using a security_message
-        and having no severity (CVSS score) assigned which is an error /
-        debugging leftover in most cases.
+        and having no severity (CVSS score) assigned or has a severity assigned
+        but dies not call security_message or an implementing function
 
         Args:
             nasl_file: The VT that is going to be checked
@@ -42,33 +96,11 @@ class CheckSecurityMessages(FileContentPlugin):
         if nasl_file.suffix == ".inc":
             return
 
-        # Policy VTs might use both, security_message and log_message
-        if (
-            "Policy/" in str(nasl_file)
-            or "PCIDSS/" in str(nasl_file)
-            or "GSHB/" in str(nasl_file)
-        ):
-            return
-
-        # don't need to check VTs having a severity (which are for sure
-        # using a security_message) or no cvss_base (which shouldn't happen and
-        # is checked in a separate step) included at all.
-        cvss_base_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)
-        cvss_detect = cvss_base_pattern.search(file_content)
-
-        if cvss_detect and cvss_detect.group("value") != "0.0":
-            return
-
-        sec_match = re.search(
-            r"security_message\s*\([\w:#.&\-!,<>\[\]("
-            r")\s\"`+'/\\\n]+\)\s*(;|;\s*(\n|#))",
-            file_content,
-            re.MULTILINE,
+        security_message_required = (
+            self._determinate_security_message_by_severity(file_content)
         )
 
-        if sec_match:
-            yield LinterError(
-                "VT is using a security_message in a VT without severity",
-                file=nasl_file,
-                plugin=self.name,
-            )
+        if security_message_required:
+            return self._check_security_message_present(nasl_file, file_content)
+        else:
+            return self._check_security_message_absent(nasl_file, file_content)


### PR DESCRIPTION
## What

Changes the `security_message` plugin to check that either:

- A `severity` is present, as is a call to `security_message`
- A `severity` is absent, as is a call to `security_message`

## Why

Closes: VTD-1930

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


