### PR TITLE
Fix: Revert security_message check changes

### DIFF
--- a/tests/plugins/test_security_messages.py
+++ b/tests/plugins/test_security_messages.py
@@ -90,8 +90,7 @@ class CheckSecurityMessagesTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT is using a security_message or implementing"
-            " function in a VT without severity",
+            "VT is using a security_message in a VT without severity",
             results[0].message,
         )
 
@@ -115,33 +114,6 @@ class CheckSecurityMessagesTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT is using a security_message or implementing "
-            "function in a VT without severity",
-            results[0].message,
-        )
-
-    def test_nok3(self):
-        nasl_file = Path(__file__).parent / "test.nasl"
-        content = (
-            'script_tag(name:"cvss_base", value:"0.0");\n'
-            'script_tag(name:"summary", value:"Foo Bar.");\n'
-            'script_tag(name:"solution_type", value:"VendorFix");\n'
-            'script_tag(name:"solution", value:"meh");\n'
-            "security_message( port:port, data:'It was possible to get the "
-            "csrf token `' + token[1] + '` via a jsonp request to: ' + "
-            "http_report_vuln_url( port:port, url:url, url_only:TRUE ) );\n"
-        )
-        fake_context = self.create_file_plugin_context(
-            nasl_file=nasl_file, file_content=content
-        )
-        plugin = CheckSecurityMessages(fake_context)
-
-        results = list(plugin.run())
-
-        self.assertEqual(len(results), 1)
-        self.assertIsInstance(results[0], LinterError)
-        self.assertEqual(
-            "VT is using a security_message or implementing"
-            " function in a VT without severity",
+            "VT is using a security_message in a VT without severity",
             results[0].message,
         )

--- a/troubadix/plugins/security_messages.py
+++ b/troubadix/plugins/security_messages.py
@@ -14,100 +14,16 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import re
 from pathlib import Path
 from typing import Iterator
 
 from troubadix.helper.patterns import ScriptTag, get_script_tag_pattern
 from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
 
-SECURITY_MESSAGE_IMPLEMENTATIONS = [
-    "security_message",
-    "http_check_remote_code",
-    "citrix_xenserver_check_report_is_vulnerable",
-    "citrix_xenserver_report_missing_patch",
-]
-
-
-def _file_contains_security_message(file_content: str) -> bool:
-    """Checks wether a VT content contains a call to security_message
-    or any function known to implement it
-
-    Args:
-        file_content (str): The content of the VT
-    """
-    return any(
-        security_message in file_content
-        for security_message in SECURITY_MESSAGE_IMPLEMENTATIONS
-    )
-
 
 class CheckSecurityMessages(FileContentPlugin):
     name = "check_security_messages"
-
-    def _check_security_message_present(
-        self, nasl_file: Path, file_content: str
-    ) -> Iterator[LinterResult]:
-        """Checks that the VT does have a
-        security_message or implementing function call
-
-        Args:
-            nasl_file (Path): The VTs path
-            file_content (str): The content of the VT
-        """
-        deprecated_pattern = get_script_tag_pattern(
-            script_tag=ScriptTag.DEPRECATED
-        )
-        if deprecated_pattern.match(file_content):
-            return
-
-        if not _file_contains_security_message(file_content):
-            yield LinterError(
-                "VT is missing a security_message or implementing"
-                " function in a VT with severity",
-                file=nasl_file,
-                plugin=self.name,
-            )
-
-    def _check_security_message_absent(
-        self, nasl_file: Path, file_content: str
-    ) -> Iterator[LinterResult]:
-        """Checks that the VT does not have a
-        security_message or implementing function call
-
-        Args:
-            nasl_file (Path): The VTs path
-            file_content (str): The content of the VT
-        """
-        # Policy VTs might use both, security_message and log_message
-        if (
-            "Policy/" in str(nasl_file)
-            or "PCIDSS/" in str(nasl_file)
-            or "GSHB/" in str(nasl_file)
-        ):
-            return
-
-        if _file_contains_security_message(file_content):
-            yield LinterError(
-                "VT is using a security_message or implementing"
-                " function in a VT without severity",
-                file=nasl_file,
-                plugin=self.name,
-            )
-
-    def _determinate_security_message_by_severity(
-        self, file_content: str
-    ) -> bool:
-        """Determinates wether a VT requires a
-        security_message or implementing function
-        call
-
-        Args:
-            file_content (str): The content of the VT
-        """
-        cvss_base_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)
-        cvss_detect = cvss_base_pattern.search(file_content)
-
-        return cvss_detect and cvss_detect.group("value") != "0.0"
 
     def check_content(
         self,
@@ -115,8 +31,8 @@ class CheckSecurityMessages(FileContentPlugin):
         file_content: str,
     ) -> Iterator[LinterResult]:
         """This script checks the passed VT if it is using a security_message
-        and having no severity (CVSS score) assigned or has a severity assigned
-        but does not call security_message or an implementing function
+        and having no severity (CVSS score) assigned which is an error /
+        debugging leftover in most cases.
 
         Args:
             nasl_file: The VT that is going to be checked
@@ -126,15 +42,33 @@ class CheckSecurityMessages(FileContentPlugin):
         if nasl_file.suffix == ".inc":
             return
 
-        security_message_required = (
-            self._determinate_security_message_by_severity(file_content)
+        # Policy VTs might use both, security_message and log_message
+        if (
+            "Policy/" in str(nasl_file)
+            or "PCIDSS/" in str(nasl_file)
+            or "GSHB/" in str(nasl_file)
+        ):
+            return
+
+        # don't need to check VTs having a severity (which are for sure
+        # using a security_message) or no cvss_base (which shouldn't happen and
+        # is checked in a separate step) included at all.
+        cvss_base_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)
+        cvss_detect = cvss_base_pattern.search(file_content)
+
+        if cvss_detect and cvss_detect.group("value") != "0.0":
+            return
+
+        sec_match = re.search(
+            r"security_message\s*\([\w:#.&\-!,<>\[\]("
+            r")\s\"`+'/\\\n]+\)\s*(;|;\s*(\n|#))",
+            file_content,
+            re.MULTILINE,
         )
 
-        if security_message_required:
-            yield from self._check_security_message_present(
-                nasl_file, file_content
-            )
-        else:
-            yield from self._check_security_message_absent(
-                nasl_file, file_content
+        if sec_match:
+            yield LinterError(
+                "VT is using a security_message in a VT without severity",
+                file=nasl_file,
+                plugin=self.name,
             )


### PR DESCRIPTION
## What

This reverts #529 while creating a new version, so the faulty `deprecation` behavior will be reverted client side with a new release

## Why

Reopens: VTD-1930

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


