### PR TITLE
Ignore misspellings in URLs

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -222,6 +222,7 @@ class CheckSpelling(FilesPlugin):
                 f"--exclude-file={codespell_exclude}",
                 f"--ignore-words={codespell_ignore}",
                 "--disable-colors",
+                "--uri-ignore-words-list *",
             ] + files_parameters
 
             with redirect_stdout(io.StringIO()) as codespell_stream:

--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -96,18 +96,6 @@ exceptions = [
     PatternInFilesCheck(
         ["PCIDSS/", "GSHB/", "attic/PCIDSS_"], r"n[iI]n\s+==>\s+inn"
     ),
-    # False positives in the GSHB/ and ITG_Kompendium/ VTs on
-    # bsi.bund.de URLs.
-    PatternInFilesCheck(
-        [
-            "GSHB/",
-            "ITG_Kompendium/",
-            "Policy/gb_policy_cipher_suites.nasl",
-            "Policy/policy_BSI-TR-03116-4.nasl",
-            "2012/gb_secpod_ssl_ciphers_weak_report.nasl",
-        ],
-        r"bund\s+==>\s+bind",
-    ),
     # False positive in this VT in German example responses.
     PatternInFileCheck(
         "gb_exchange_server_CVE-2021-26855_active.nasl", r"ist\s+==>\s+is"


### PR DESCRIPTION
## What
This PR generalizes the handling of misspelling in URLs by calling codespell with `--uri-ignore-words-list *`. This causes all misspellings in URLs and emails to be ignored.

## Why
To ignore misspellings in URLs.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
I confirmed that this change doesn't degrade the behavior of the existing exclusions via
```
# troubadix --include-tests CheckSpelling --files $(grep -r "bsi.bund.de" ../vulnerability-tests/nasl)
ℹ Start linting 659 files ... 
ℹ Time elapsed: 0:00:00.199386
  Plugin                                             Errors Warnings
  -------------------------------------------------------------------
  -------------------------------------------------------------------
ℹ sum                                                     0        0
```
I used `bsi.bund.de` in this example, because it has been previously excluded manually and I usually causes erroneous spelling errors:
```
# codespell nasl/common/Policy/policy_BSI-TR-03116-4.nasl         
nasl/common/Policy/policy_BSI-TR-03116-4.nasl:38: bund ==> bind, bound
```