### PR TITLE
Fix: Codespell argument

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -210,7 +210,7 @@ class CheckSpelling(FilesPlugin):
                 f"--exclude-file={codespell_exclude}",
                 f"--ignore-words={codespell_ignore}",
                 "--disable-colors",
-                "--uri-ignore-words-list *",
+                "--uri-ignore-words-list=*",
             ] + files_parameters
 
             with redirect_stdout(io.StringIO()) as codespell_stream:


### PR DESCRIPTION
## What
This PR fixes https://github.com/greenbone/troubadix/pull/537 by correcting the syntax of arguments.
Currently, the `--uri-ignore-words-list` has no parameter, so it's no effective.

We could use either `"--uri-ignore-words-list", "*",` or `"--uri-ignore-words-list=*",` and I opted for the latter to align with the other arguments.

## Why
To actually make Codespell aware of the argument and parameter.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


