### PR TITLE
Add: Exception to check_badwords plugin.

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -78,6 +78,7 @@ EXCEPTIONS = [
     'url = "/openvas.jsp";',
     'if( "OpenVAS RCE Test" >< buf )',
     'the file "/openvas.jsp" was created',
+    "/var/lib/openvas/plugins/",
 ]
 
 STARTS_WITH_EXCEPTIONS = [


### PR DESCRIPTION
## What
See title...

Notes:
- No dedicated release required, i will create another PR tomorrow
- Used in at least `template.nasl` and shouldn't be reported for that

## Why

Exclude false positives

## References

N/A