### PR TITLE
Change: Exclude template and testing VTs from some checks.

### DIFF
--- a/troubadix/plugins/copyright_year.py
+++ b/troubadix/plugins/copyright_year.py
@@ -15,6 +15,13 @@ _IGNORE_FILES = (
     "gb_hirschmann_telnet_detect.nasl",
 )
 
+_FULL_IGNORE_FILES = (
+    "test_version_func_inc.nasl",
+    "policy_control_template.nasl",
+    "template.nasl",
+    "test_ipv6_packet_forgery.nasl",
+)
+
 
 class CheckCopyrightYear(LineContentPlugin):
     """This steps checks if a VT contains a Copyright statement containing a
@@ -29,7 +36,9 @@ class CheckCopyrightYear(LineContentPlugin):
         nasl_file: Path,
         lines: Iterable[str],
     ) -> Iterator[LinterResult]:
-        if nasl_file.suffix == ".inc":
+        if nasl_file.suffix == ".inc" or is_ignore_file(
+            nasl_file, _FULL_IGNORE_FILES
+        ):
             return
 
         creation_date = ""

--- a/troubadix/plugins/creation_date.py
+++ b/troubadix/plugins/creation_date.py
@@ -33,7 +33,10 @@ class CheckCreationDate(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         if not "creation_date" in file_content:

--- a/troubadix/plugins/cve_format.py
+++ b/troubadix/plugins/cve_format.py
@@ -37,7 +37,10 @@ class CheckCVEFormat(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         tag_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)

--- a/troubadix/plugins/cvss_format.py
+++ b/troubadix/plugins/cvss_format.py
@@ -30,7 +30,10 @@ class CheckCVSSFormat(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         cvss_base_pattern = get_script_tag_pattern(ScriptTag.CVSS_BASE)

--- a/troubadix/plugins/dependencies.py
+++ b/troubadix/plugins/dependencies.py
@@ -45,12 +45,16 @@ class CheckDependencies(FilePlugin):
         if self.context.nasl_file.suffix == ".inc":
             return
 
+        file_content = self.context.file_content
+
+        if "# troubadix: disable=template_nd_test_files_fps" in file_content:
+            return
+
         dependencies_pattern = _get_special_script_tag_pattern(
             "dependencies", flags=re.DOTALL | re.MULTILINE
         )
 
         root = self.context.root
-        file_content = self.context.file_content
 
         matches = dependencies_pattern.finditer(file_content)
 

--- a/troubadix/plugins/dependency_category_order.py
+++ b/troubadix/plugins/dependency_category_order.py
@@ -91,7 +91,11 @@ class CheckDependencyCategoryOrder(FileContentPlugin):
         In addition it is not allowed for VTs to have a direct dependency
         to VTs from within the ACT_SCANNER category.
         """
-        if not "script_dependencies(" in file_content:
+        if (
+            nasl_file.suffix == ".inc"
+            or not "script_dependencies(" in file_content
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         category_pattern = get_special_script_tag_pattern(

--- a/troubadix/plugins/deprecated_dependency.py
+++ b/troubadix/plugins/deprecated_dependency.py
@@ -41,10 +41,11 @@ class CheckDeprecatedDependency(FilePlugin):
 
         file_content = self.context.file_content
 
-        if not "script_dependencies(" in file_content:
+        if (
+            not "script_dependencies(" in file_content
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
-
-        root = self.context.root
 
         dependencies_pattern = get_special_script_tag_pattern(
             SpecialScriptTag.DEPENDENCIES
@@ -62,6 +63,8 @@ class CheckDeprecatedDependency(FilePlugin):
         deprecated = deprecated_pattern.search(file_content)
         if deprecated:
             return
+
+        root = self.context.root
 
         for match in matches:
             if match:

--- a/troubadix/plugins/duplicate_oid.py
+++ b/troubadix/plugins/duplicate_oid.py
@@ -41,10 +41,15 @@ class CheckDuplicateOID(FilesPlugin):
             if not nasl_file.suffix == ".nasl":
                 continue
 
+            content = nasl_file.read_text(encoding=CURRENT_ENCODING)
+
+            if "# troubadix: disable=template_nd_test_files_fps" in content:
+                continue
+
             nasl_file_root = get_path_from_root(nasl_file, self.context.root)
 
             oid = None
-            content = nasl_file.read_text(encoding=CURRENT_ENCODING)
+
             match = get_special_script_tag_pattern(SpecialScriptTag.OID).search(
                 content
             )

--- a/troubadix/plugins/duplicated_script_tags.py
+++ b/troubadix/plugins/duplicated_script_tags.py
@@ -37,8 +37,13 @@ class CheckDuplicatedScriptTags(FilePlugin):
         if self.context.nasl_file.suffix == ".inc":
             return
 
-        special_script_tag_patterns = get_special_script_tag_patterns()
         file_content = self.context.file_content
+
+        if "# troubadix: disable=template_nd_test_files_fps" in file_content:
+            return
+
+        special_script_tag_patterns = get_special_script_tag_patterns()
+
         for tag, pattern in special_script_tag_patterns.items():
             # TBD: script_name might also look like this:
             # script_name("MyVT (Windows)");

--- a/troubadix/plugins/missing_desc_exit.py
+++ b/troubadix/plugins/missing_desc_exit.py
@@ -49,7 +49,10 @@ class CheckMissingDescExit(FileContentPlugin):
             file_content: The content of the file that is going to be checked
 
         """
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         match = re.search(

--- a/troubadix/plugins/qod.py
+++ b/troubadix/plugins/qod.py
@@ -64,6 +64,9 @@ class CheckQod(FilePlugin):
 
         file_content = self.context.file_content
 
+        if "# troubadix: disable=template_nd_test_files_fps" in file_content:
+            return
+
         qod_pattern = get_script_tag_pattern(ScriptTag.QOD)
         qod_type_pattern = get_script_tag_pattern(ScriptTag.QOD_TYPE)
 

--- a/troubadix/plugins/reporting_consistency.py
+++ b/troubadix/plugins/reporting_consistency.py
@@ -53,7 +53,8 @@ IGNORE_FILES = [
     "GSHB/GSHB_Kompendium.nasl",
     "/policy_control_template.nasl",
     "/template.nasl",
-    "/examples/test_ipv6_packet_forgery.nasl",
+    "test_ipv6_packet_forgery.nasl",
+    "test_version_func_inc.nasl",
 ]
 
 

--- a/troubadix/plugins/script_calls_empty_values.py
+++ b/troubadix/plugins/script_calls_empty_values.py
@@ -41,7 +41,10 @@ class CheckScriptCallsEmptyValues(FileContentPlugin):
         Checks for empty 'value:""' in script calls. Excepted from this is
         script_add_preferences().
         """
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         matches = _get_tag_pattern(name=r".*", value=r"").finditer(file_content)

--- a/troubadix/plugins/script_calls_recommended.py
+++ b/troubadix/plugins/script_calls_recommended.py
@@ -49,7 +49,10 @@ class CheckScriptCallsRecommended(FileContentPlugin):
         - script_require_keys
         - script_mandatory_keys
         """
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         if _get_special_script_tag_pattern(

--- a/troubadix/plugins/script_category.py
+++ b/troubadix/plugins/script_category.py
@@ -31,7 +31,10 @@ class CheckScriptCategory(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         own_category_match = re.search(

--- a/troubadix/plugins/script_copyright.py
+++ b/troubadix/plugins/script_copyright.py
@@ -44,7 +44,10 @@ class CheckScriptCopyright(FileContentPlugin):
             nasl_file: The VT that shall be checked
             file_content: str representing the file content
         """
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         if not re.search(

--- a/troubadix/plugins/script_family.py
+++ b/troubadix/plugins/script_family.py
@@ -101,7 +101,10 @@ class CheckScriptFamily(FileContentPlugin):
     ) -> Iterator[LinterResult]:
         """This script checks VT for the existence / validity
         of its script family"""
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         family_pattern = get_special_script_tag_pattern(SpecialScriptTag.FAMILY)

--- a/troubadix/plugins/script_tags_mandatory.py
+++ b/troubadix/plugins/script_tags_mandatory.py
@@ -55,7 +55,10 @@ class CheckScriptTagsMandatory(FileContentPlugin):
         - script_family
         - script_copyright
         """
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         for tag in MANDATORY_TAGS:

--- a/troubadix/plugins/script_version_and_last_modification_tags.py
+++ b/troubadix/plugins/script_version_and_last_modification_tags.py
@@ -58,10 +58,13 @@ class CheckScriptVersionAndLastModificationTags(FileContentPlugin):
             nasl_file: The VT that shall be checked
             file_content: The content of the VT that shall be checked
         """
-        self.fix_last_modification_and_version = False
-
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
+
+        self.fix_last_modification_and_version = False
 
         match_script_version_any = re.search(
             pattern=SCRIPT_VERSION_ANY_VALUE_PATTERN,

--- a/troubadix/plugins/solution_type.py
+++ b/troubadix/plugins/solution_type.py
@@ -45,7 +45,10 @@ class CheckSolutionType(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         has_severity = True

--- a/troubadix/plugins/using_display.py
+++ b/troubadix/plugins/using_display.py
@@ -35,6 +35,9 @@ class CheckUsingDisplay(FileContentPlugin):
         nasl_file: Path,
         file_content: str,
     ) -> Iterator[LinterResult]:
+        if "# troubadix: disable=template_nd_test_files_fps" in file_content:
+            return
+
         display_matches = re.finditer(
             r".*(display\s*\([^)]+\)\s*;)", file_content
         )

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -50,7 +50,10 @@ class CheckValidOID(FileContentPlugin):
             file_content: The content of the nasl_file
 
         """
-        if nasl_file.suffix == ".inc":
+        if (
+            nasl_file.suffix == ".inc"
+            or "# troubadix: disable=template_nd_test_files_fps" in file_content
+        ):
             return
 
         security_template = "Security Advisory"

--- a/troubadix/standalone_plugins/version_updated.py
+++ b/troubadix/standalone_plugins/version_updated.py
@@ -23,6 +23,7 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import Iterable, List
 
+from troubadix.helper import is_ignore_file
 from troubadix.helper.patterns import (
     LAST_MODIFICATION_ANY_VALUE_PATTERN,
     SCRIPT_VERSION_ANY_VALUE_PATTERN,
@@ -35,6 +36,12 @@ SCRIPT_VERSION_PATTERN = re.compile(
 SCRIPT_LAST_MODIFICATION_PATTERN = re.compile(
     r"^\+\s*" + LAST_MODIFICATION_ANY_VALUE_PATTERN, re.MULTILINE
 )
+
+_IGNORE_FILES = [
+    "/template.nasl",
+    "/policy_control_template.nasl",
+    "test_version_func_inc.nasl",
+]
 
 
 def file_type(string: str) -> Path:
@@ -92,8 +99,12 @@ def check_version_updated(files: List[Path], commit_range: str) -> bool:
 
     rcode = True
     for nasl_file in files:
-        if nasl_file.suffix != ".nasl" or not nasl_file.exists():
-            continue
+        if (
+            nasl_file.suffix != ".nasl"
+            or not nasl_file.exists()
+            or is_ignore_file(nasl_file, _IGNORE_FILES)
+        ):
+            return
 
         print(f"Check file {nasl_file}")
         text = git(


### PR DESCRIPTION
## What
See title

To test run Troubadix with something like e.g. the following:

```
troubadix -vv --files template.nasl policy_control_template.nasl path/to/test_version_func_inc.nasl path/to/test_ipv6_packet_forgery.nasl
```

and see the false positives reports for these test / template files. Repeat it from this branch and against the VTs in the branch of the PR linked below and the false positives should be gone.

Notes:
- I have kept this a little bit "basic" on purpose because there are only three VTs / nasl files which currently needs to be excluded. If the exclusion for e.g. different keywords or similar are required we might want to handle this in a more advanced way in the future
- Using such "exclusion" keywords makes it easier to add additional testing files / templates without touching Troubadix every time
- `template_nd_test_files_fps` naming is TBD, better suggestions are welcome
- Inspired by the `# pylint: disable=something` of Pylint (see https://pylint.readthedocs.io/en/latest/user_guide/messages/message_control.html)
- The `copyright_year.py` is also a little bit special as it is a `LineContentPlugin`. I have raised VTD-1964 to make it a `FileContentPlugin` and then we could use the more generic approach similar to the others once that task has been tackled
- In one case (dependency_category_order.py)  `.inc` files didn't got excluded and i have also added a check for that
- In a few other cases e.g. `root = self.context.root` got defined but then the plugin might have returned early without using it so a few of these cases have been moved a little bit more down "while on it". Haven't explicitly mentioned that in the commit message because it's a minor change which IMHO doesn't worth it to be included in the changelog

## Why
To make PRs for the files in question (like e.g. greenbone/vulnerability-tests#4445) to pass without having an admin overwriting the (wrongly) failed checks

## References
None