### PR TITLE
Add: troubadix-allowed-rev-diff tool

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -269,6 +269,37 @@ files = [
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
+name = "gitdb"
+version = "4.0.10"
+description = "Git Object Database"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "gitdb-4.0.10-py3-none-any.whl", hash = "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"},
+    {file = "gitdb-4.0.10.tar.gz", hash = "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.31"
+description = "GitPython is a Python library used to interact with Git repositories"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "GitPython-3.1.31-py3-none-any.whl", hash = "sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d"},
+    {file = "GitPython-3.1.31.tar.gz", hash = "sha256:8ce3bcf69adfdf7c7d503e78fd3b1c492af782d58893b650adb2ac8912ddd573"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -741,6 +772,18 @@ files = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.0"
+description = "A pure Python implementation of a sliding window memory map manager"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
+    {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
@@ -943,4 +986,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "da0fe0d41c9ebe014d1b5c90654c790355f0a2dd3f8ef4c5df1f55577629ee0b"
+content-hash = "9e12b036457d1349ae125dca6d2340be62ce0a669e873b1647e20ae9ce61e408"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ codespell = "^2.0.0"
 python-magic = "^0.4.25"
 chardet = ">=4,<6"
 validators = ">=0.18.2,<0.21.0"
+gitpython = "^3.1.31"
 
 [tool.poetry.dev-dependencies]
 autohooks = ">=21.7.0"
@@ -82,6 +83,7 @@ troubadix-version-updated = 'troubadix.standalone_plugins.version_updated:main'
 troubadix-no-solution = 'troubadix.standalone_plugins.no_solution:main'
 troubadix-changed-packages = 'troubadix.standalone_plugins.changed_packages.changed_packages:main'
 troubadix-changed-cves = 'troubadix.standalone_plugins.changed_cves:main'
+troubadix-allowed-rev-diff = 'troubadix.standalone_plugins.allowed_rev_diff:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/troubadix/standalone_plugins/allowed_rev_diff.py
+++ b/troubadix/standalone_plugins/allowed_rev_diff.py
@@ -43,7 +43,7 @@ def parse_arguments() -> Namespace:
         type=str,
         default=DEFAULT_IGNORED_LINESTARTS,
         help="A list of line starts which will make the line be ignored. "
-        f"Default: {', '.join(DEFAULT_IGNORED_LINESTARTS)}",
+        "Default: %(default)s",
     )
 
     ignored_linestart_group.add_argument(
@@ -53,7 +53,7 @@ def parse_arguments() -> Namespace:
         default=DEFAULT_IGNORED_LINESTARTS,
         help="The file containing a list of line starts, "
         "separated by newlines, which will make the line be ignored. "
-        f"Default values used: {', '.join(DEFAULT_IGNORED_LINESTARTS)}",
+        "Default values used: %(default)s",
     )
 
     pattern_group = argument_parser.add_mutually_exclusive_group(required=True)

--- a/troubadix/standalone_plugins/allowed_rev_diff.py
+++ b/troubadix/standalone_plugins/allowed_rev_diff.py
@@ -144,7 +144,13 @@ def main() -> int:
 
     result = check_diff(diff.splitlines(), ignored_linestarts, patterns)
 
-    return 1 if result else 0
+    if result:
+        print("The following lines don't match the any pattern:")
+        print("\n".join(result))
+
+        return 1
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/troubadix/standalone_plugins/allowed_rev_diff.py
+++ b/troubadix/standalone_plugins/allowed_rev_diff.py
@@ -112,12 +112,15 @@ def read_ignored_linestarts(path: Path) -> List[str]:
         return None
 
     with open(path, "r", encoding="UTF-8") as file:
-        return [line[:-1] for line in file.readlines()]
+        return [line.removesuffix("\n") for line in file.readlines()]
 
 
 def read_patterns(path: Path) -> List[Pattern]:
     with open(path, "r", encoding="UTF-8") as file:
-        return [re.compile(pattern[:-1]) for pattern in file.readlines()]
+        return [
+            re.compile(pattern.removesuffix("\n"))
+            for pattern in file.readlines()
+        ]
 
 
 def main() -> int:

--- a/troubadix/standalone_plugins/allowed_rev_diff.py
+++ b/troubadix/standalone_plugins/allowed_rev_diff.py
@@ -41,7 +41,7 @@ def parse_arguments() -> Namespace:
         nargs="*",
         type=str,
         help="A list of line starts which will make the line be ignored. "
-        "Default: ['diff ', 'index ', '--- ', '+++ ', '@@ ']",
+        f"Default: {', '.join(DEFAULT_IGNORED_LINESTARTS)}",
     )
 
     ignored_linestart_group.add_argument(
@@ -49,7 +49,7 @@ def parse_arguments() -> Namespace:
         type=Path,
         help="The file containing a list of line starts, "
         "separated by newlines, which will make the line be ignored. "
-        "Default: ['diff ', 'index ', '--- ', '+++ ', '@@ ']",
+        f"Default values used: {', '.join(DEFAULT_IGNORED_LINESTARTS)}",
     )
 
     pattern_group = argument_parser.add_mutually_exclusive_group(required=True)

--- a/troubadix/standalone_plugins/allowed_rev_diff.py
+++ b/troubadix/standalone_plugins/allowed_rev_diff.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import re
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from re import Pattern
+from typing import List
+
+from git.repo.base import Repo
+
+DEFAULT_IGNORED_LINESTARTS = ["diff ", "index ", "--- ", "+++ ", "@@ "]
+
+
+def ensure_pattern(argument: str) -> Pattern:
+    return re.compile(argument)
+
+
+def parse_arguments() -> Namespace:
+    argument_parser = ArgumentParser(
+        "Tool to check that the target rev only has diffs conforming to "
+        "the given patterns regarding the source rev"
+    )
+
+    argument_parser.add_argument(
+        "-d",
+        "--directory",
+        default=Path.cwd(),
+        type=Path,
+        help="The directory the repository to check is located in. "
+        "Defaults to 'pwd'",
+    )
+
+    ignored_linestart_group = argument_parser.add_mutually_exclusive_group()
+
+    ignored_linestart_group.add_argument(
+        "-i",
+        "--ignored-linestarts",
+        nargs="*",
+        type=str,
+        help="A list of line starts which will make the line be ignored. "
+        "Default: ['diff ', 'index ', '--- ', '+++ ', '@@ ']",
+    )
+
+    ignored_linestart_group.add_argument(
+        "--ignored-linestart-file",
+        type=Path,
+        help="The file containing a list of line starts, "
+        "separated by newlines, which will make the line be ignored. "
+        "Default: ['diff ', 'index ', '--- ', '+++ ', '@@ ']",
+    )
+
+    pattern_group = argument_parser.add_mutually_exclusive_group(required=True)
+
+    pattern_group.add_argument(
+        "-p",
+        "--patterns",
+        type=ensure_pattern,
+        nargs="*",
+        help="The list of patterns to check the diff for",
+    )
+
+    pattern_group.add_argument(
+        "--pattern-file",
+        type=Path,
+        help="The file containing the list of patterns, separated by newlines, "
+        "to check the diff for",
+    )
+
+    argument_parser.add_argument(
+        "-s", "--source", type=str, required=True, help="The upstream rev"
+    )
+
+    argument_parser.add_argument(
+        "-t", "--target", type=str, required=True, help="The downstream rev"
+    )
+
+    return argument_parser.parse_args()
+
+
+def check_diff_line_starts_with_ignored_linestart(
+    line: str, ignored_linestarts: List[str]
+) -> bool:
+    return any(
+        linestart
+        for linestart in ignored_linestarts
+        if line.startswith(linestart)
+    )
+
+
+def check_diff_line_matches_pattern(line: str, patterns: List[Pattern]) -> bool:
+    return any(pattern for pattern in patterns if pattern.match(line))
+
+
+def check_diff(
+    lines: List[str], ignored_linestarts: List[str], patterns: List[Pattern]
+) -> List[str]:
+    return [
+        line
+        for line in lines
+        if not check_diff_line_starts_with_ignored_linestart(
+            line, ignored_linestarts
+        )
+        and not check_diff_line_matches_pattern(line, patterns)
+    ]
+
+
+def read_ignored_linestarts(path: Path) -> List[str]:
+    if not path:
+        return None
+
+    with open(path, "r", encoding="UTF-8") as file:
+        return [line[:-1] for line in file.readlines()]
+
+
+def read_patterns(path: Path) -> List[Pattern]:
+    with open(path, "r", encoding="UTF-8") as file:
+        return [re.compile(pattern[:-1]) for pattern in file.readlines()]
+
+
+def main() -> int:
+    arguments = parse_arguments()
+
+    ignored_linestarts = (
+        arguments.ignored_linestarts
+        or read_ignored_linestarts(arguments.ignored_linestart_file)
+        or DEFAULT_IGNORED_LINESTARTS
+    )
+
+    patterns = arguments.patterns or read_patterns(arguments.pattern_file)
+
+    repo = Repo(arguments.directory)
+
+    target = repo.commit(arguments.target)
+
+    merge_base = repo.merge_base(repo.commit(arguments.source), target)[0]
+
+    diff = repo.git.diff(target, merge_base, unified=0)
+
+    result = check_diff(diff.splitlines(), ignored_linestarts, patterns)
+
+    return 1 if result else 0
+
+
+if __name__ == "__main__":
+    main()

--- a/troubadix/standalone_plugins/allowed_rev_diff.py
+++ b/troubadix/standalone_plugins/allowed_rev_diff.py
@@ -1,19 +1,6 @@
-# Copyright (C) 2023 Greenbone AG
+# SPDX-FileCopyrightText: 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 import re


### PR DESCRIPTION
## What

Adds a tool to troubadix that checks the diff between separate revs conforms to given patterns.

## Why

Required for the release branch
Part of: VTD-1666

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


