### PR TITLE
Fix: Using a (wrong) return instead of the (correct) continue

### DIFF
--- a/troubadix/standalone_plugins/version_updated.py
+++ b/troubadix/standalone_plugins/version_updated.py
@@ -104,7 +104,7 @@ def check_version_updated(files: List[Path], commit_range: str) -> bool:
             or not nasl_file.exists()
             or is_ignore_file(nasl_file, _IGNORE_FILES)
         ):
-            return
+            continue
 
         print(f"Check file {nasl_file}")
         text = git(


### PR DESCRIPTION
## What
Just had noticed that the previously used `continue` was replaced by a `return` in #550 wrongly due to a copy'n'paste issue.

![Screenshot_2023-04-26_16-04-42](https://user-images.githubusercontent.com/34644702/234600831-8deefa3e-b84e-4cd2-a3eb-30fafcf90f76.png)

## Why

Fix a bug introduced in #550

## References

None