### PR TITLE
Change: Update exclusions in version_updated plugin.

### DIFF
--- a/troubadix/standalone_plugins/version_updated.py
+++ b/troubadix/standalone_plugins/version_updated.py
@@ -38,9 +38,10 @@ SCRIPT_LAST_MODIFICATION_PATTERN = re.compile(
 )
 
 _IGNORE_FILES = [
-    "/template.nasl",
-    "/policy_control_template.nasl",
+    "template.nasl",
+    "policy_control_template.nasl",
     "test_version_func_inc.nasl",
+    "test_ipv6_packet_forgery.nasl",
 ]
 
 


### PR DESCRIPTION
## What
- No dedicated release required, can be shipped with the next one
- Minor follow-up change to #550
- As the file name seems to not include a `/` like seen in the output below that one was dropped
- One file to be excluded was also missing

```
attic/test_ipv6_packet_forgery.nasl: Missing updated script_version
attic/test_ipv6_packet_forgery.nasl: Missing updated last_modification
policy_control_template.nasl: Missing updated script_version
policy_control_template.nasl: Missing updated last_modification
template.nasl: Missing updated script_version
template.nasl: Missing updated last_modification
Check file attic/test_ipv6_packet_forgery.nasl
Check file policy_control_template.nasl
Check file template.nasl
Error: Process completed with exit code 2.
```

## Why

Exclude additional false positives for .nasl files which doesn't have any of such version strings.

## References

None