### PR TITLE
Change: Use python-version instead of version

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -23,7 +23,7 @@ jobs:
         uses: greenbone/actions/lint-python@v2
         with:
           packages: troubadix tests
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
   test:
     name: Run all tests
@@ -40,7 +40,7 @@ jobs:
       - name: Install python, poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Run unit tests
         run: |
           poetry run python -m unittest -v
@@ -56,7 +56,7 @@ jobs:
       - name: Install python, poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: 3.9
+          python-version: 3.9
       - name: Install codecov-python
         run: poetry run python -m pip install codecov
       - name: Run unit tests


### PR DESCRIPTION
## What
This PR prevents the deprecation warning ```Input 'version' has been deprecated with message: version input is deprecated. Please use `python-version` input instead.```.

## Why
After https://github.com/greenbone/actions/pull/552, the `version` input is deprecated and `python-version` should to be used instead.

## References
The same as https://github.com/greenbone/notus-generator/pull/799.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


