### PR TITLE
Change: Extend Badwords plugin with an additional term and test case.

### DIFF
--- a/tests/plugins/test_badwords.py
+++ b/tests/plugins/test_badwords.py
@@ -60,3 +60,16 @@ class TestBadwords(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 0)
+
+    def test_exception_ok(self):
+        path = Path("some/include.inc")
+        content = '# HostDetails/NVT                 => "1.2.3.4"'
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, lines=content.splitlines()
+        )
+
+        plugin = CheckBadwords(fake_context)
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)

--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -31,6 +31,12 @@ DEFAULT_BADWORDS = [
     "OpenVAS",
     "4f70656e564153",
     "6f70656e766173",
+    # nb:
+    # - VT should be used instead
+    # - using a space before/after to make the check a little bit more strict
+    # - this could be made less strict later once the whole feed is "clean"
+    "NVT ",
+    " NVT",
 ]
 
 _IGNORE_FILES = [
@@ -79,6 +85,8 @@ EXCEPTIONS = [
     'if( "OpenVAS RCE Test" >< buf )',
     'the file "/openvas.jsp" was created',
     "/var/lib/openvas/plugins/",
+    "INVT ",  # INVT Electric VT Designer
+    "HostDetails/NVT",  # Can't be changed right now...
 ]
 
 STARTS_WITH_EXCEPTIONS = [
@@ -120,8 +128,13 @@ class CheckBadwords(LineContentPlugin):
                         for filename, value in COMBINED
                     )
                 ):
+                    report = f"Badword in line {i:5}: {line}"
+                    if "NVT" in line:
+                        report += (
+                            '\nNote/Hint: Please use the term "VT" instead.'
+                        )
                     yield LinterError(
-                        f"Badword in line {i:5}: {line}",
+                        report,
                         plugin=self.name,
                         file=nasl_file,
                         line=i,


### PR DESCRIPTION
## What
See title...

Notes:
- Not sure how easily it could be done but maybe we could also change the  `DEFAULT_BADWORDS` list to a dict and allow an optional note / hint what to use instead? Some one else would need to take over though.
- Please make sure to review and merge all other current open PRs before doing a release for this change.

The reporting itself looks like e.g. the following now:

```
ℹ Checking common/gb_unknown_os_service_reporting.nasl (20152/90545)
ℹ     Results for plugin check_badwords
×         Badword in line    40:   the following NVTs:
          Note/Hint: Please use the term "VT" instead.
```

## Why
Instead of `NVT` the term `VT` should be used nowadays

## References
N/A

## Checklist

- [x] Tests