### PR TITLE
Change: Revert "Change: Temporarily disable --hard-encoding-detection due to an issue in codespell 2.2.4"

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -210,8 +210,7 @@ class CheckSpelling(FilesPlugin):
                 for nasl_file in self.context.nasl_files[i : i + batch_size]
             ]
             codespell_arguments = [
-                # nb: Temporarily disabled due to an issue in codespell 2.2.4.
-                # "--hard-encoding-detection",
+                "--hard-encoding-detection",
                 "--dictionary=-",
                 f"--dictionary={codespell_additions}",
                 f"--exclude-file={codespell_exclude}",


### PR DESCRIPTION
## What
Reverts greenbone/troubadix#518

## Why
Now that [Codespell 2.2.5](https://github.com/codespell-project/codespell/releases/tag/v2.2.5) has been released which includes the fix from codespell-project/codespell#2785 we should revert the previous workaround from our side again and use the `chardet` option to detect the encoding.

## References
Closes VTD-1940