### PR TITLE
Change: Add a valid VT to the ignore list of the reporting_consistency Plugin.

### DIFF
--- a/troubadix/plugins/reporting_consistency.py
+++ b/troubadix/plugins/reporting_consistency.py
@@ -55,6 +55,7 @@ IGNORE_FILES = [
     "/template.nasl",
     "test_ipv6_packet_forgery.nasl",
     "test_version_func_inc.nasl",
+    "pre2008/mssql_brute_force.nasl",
 ]
 
 


### PR DESCRIPTION
## What
See title

Notes:
- Should be merged #589 so that that PR is included in the release after merging this PR here
- Maybe also merge possible "dependency updates" first which could arrive next week

## Why
So that we can add a `log_message() call to the updated VT from greenbone/vulnerability-tests#5829

## References
None