### PR TITLE
Change: Add 'package_unreliable' to the allowed qod_type values.

### DIFF
--- a/troubadix/plugins/qod.py
+++ b/troubadix/plugins/qod.py
@@ -48,6 +48,7 @@ VALID_QOD_TYPES = [
     "remote_banner_unreliable",
     "executable_version_unreliable",
     "general_note",
+    "package_unreliable",
 ]
 
 


### PR DESCRIPTION
## What
The new `package_unreliable` qod_type had been introduced via
- AP-1928
- SC-506
- greenbone/gsa#3353
- greenbone/gvmd#1782
- greenbone/ospd-openvas#605
in our software stack but wasn't added to Troubadix in the past.

Note: #590 should be merged first before merging this so that both are included in the new release

## Why
Allow the already implemented new qod_type in VTs.

## References
N/A