### PR TITLE
Change: Remove a few "Badwords" exceptions not required anymore.

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -85,7 +85,6 @@ EXCEPTIONS = [
     "INVT ",  # INVT Electric VT Designer
     "invt_",  # cpe:/a:invt_electric
     "HostDetails/NVT",  # Can't be changed right now...
-    "# LSS-NVT-",  # Identifier from a third-party which shouldn't be changed
     ", nvt:",  # Can't be changed right now...
     "Hu1nvt5qm",  # Part of a bigger blob
     "gz3nvtPjk",  # Same as above
@@ -96,7 +95,6 @@ STARTS_WITH_EXCEPTIONS = [
     "# OpenVAS Vulnerability Test",
     "# OpenVAS Include File",
     "  script_",
-    "# $Id: ",
 ]
 
 COMBINED = [


### PR DESCRIPTION
## What
Both strings doesn't exist in the feed anymore (due to some license header updating works) and the exceptions can be removed accordingly.

Note: We might want to merge this before #595 so that both are included in the same release.

## Why

Less code and more strict checks due to less exceptions.

## References

None