### PR TITLE
Change: Remove now unnecessary exclusions in badwords plugin.

### DIFF
--- a/tests/plugins/test_badwords.py
+++ b/tests/plugins/test_badwords.py
@@ -37,15 +37,19 @@ class TestBadwords(PluginTestCase):
 
         results = list(plugin.run())
 
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             "Badword in line     1: openvas is a bad word",
             results[0].message,
         )
         self.assertEqual(
-            "Badword in line    10: OpenVAS is a scanner",
+            "Badword in line     6: # OpenVAS Vulnerability Test",
             results[1].message,
+        )
+        self.assertEqual(
+            "Badword in line    10: OpenVAS is a scanner",
+            results[2].message,
         )
 
     def test_combined(self):

--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -92,7 +92,6 @@ EXCEPTIONS = [
 ]
 
 STARTS_WITH_EXCEPTIONS = [
-    "# OpenVAS Vulnerability Test",
     "# OpenVAS Include File",
     "  script_",
 ]

--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -92,7 +92,6 @@ EXCEPTIONS = [
 ]
 
 STARTS_WITH_EXCEPTIONS = [
-    "# OpenVAS Include File",
     "  script_",
 ]
 


### PR DESCRIPTION
## What
- As of today there won't be any VTs having `# OpenVAS Vulnerability Test` and includes having `# OpenVAS Include File` in the header anymore
- Parity PR for:
  - greenbone/vulnerability-tests#6383
  - greenbone/vulnerability-tests#6412

No dedicated release required, i will create another PR later this week after which we can do a new release

## Why

More strict checks and less code

## References

N/A