### PR TITLE
Add: Badword exclude

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -89,6 +89,7 @@ EXCEPTIONS = [
     "Hu1nvt5qm",  # Part of a bigger blob
     "gz3nvtPjk",  # Same as above
     "0EAnvtBAK",  # Same as above
+    "technocrackers",  # Author name of a wordpress plugin
 ]
 
 STARTS_WITH_EXCEPTIONS = [


### PR DESCRIPTION
## What
This PR adds a badword exclude.

## Why
`technocrackers` is the author of https://de.wordpress.org/plugins/woo-bulk-price-update/ and not a bad word.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


