### PR TITLE
Change: Downgrade validators to 0.20.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -310,6 +310,17 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
 name = "dill"
 version = "0.3.7"
 description = "serialize all of Python"
@@ -918,25 +929,19 @@ files = [
 
 [[package]]
 name = "validators"
-version = "0.22.0"
-description = "Python Data Validation for Humans™"
+version = "0.20.0"
+description = "Python Data Validation for Humans™."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.4"
 files = [
-    {file = "validators-0.22.0-py3-none-any.whl", hash = "sha256:61cf7d4a62bbae559f2e54aed3b000cea9ff3e2fdbe463f51179b92c58c9585a"},
-    {file = "validators-0.22.0.tar.gz", hash = "sha256:77b2689b172eeeb600d9605ab86194641670cdb73b60afd577142a9397873370"},
+    {file = "validators-0.20.0.tar.gz", hash = "sha256:24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a"},
 ]
 
+[package.dependencies]
+decorator = ">=3.4.0"
+
 [package.extras]
-docs-offline = ["myst-parser (>=2.0.0)", "pypandoc-binary (>=1.11)", "sphinx (>=7.1.1)"]
-docs-online = ["mkdocs (>=1.5.2)", "mkdocs-git-revision-date-localized-plugin (>=1.2.0)", "mkdocs-material (>=9.2.6)", "mkdocstrings[python] (>=0.22.0)", "pyaml (>=23.7.0)"]
-hooks = ["pre-commit (>=3.3.3)"]
-package = ["build (>=1.0.0)", "twine (>=4.0.2)"]
-runner = ["tox (>=4.11.1)"]
-sast = ["bandit[toml] (>=1.7.5)"]
-testing = ["pytest (>=7.4.0)"]
-tooling = ["black (>=23.7.0)", "pyright (>=1.1.325)", "ruff (>=0.0.287)"]
-tooling-extras = ["pyaml (>=23.7.0)", "pypandoc-binary (>=1.11)", "pytest (>=7.4.0)"]
+test = ["flake8 (>=2.4.0)", "isort (>=4.2.2)", "pytest (>=2.2.3)"]
 
 [[package]]
 name = "wrapt"
@@ -1025,4 +1030,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0f38ae58c22a8539b4798afea7ac93a5e906121a6098791bd5cd49599f3afbc0"
+content-hash = "a750ce9ff5bbd1f96e62ed97e86052d0979f388009726e9e5483eb95ce83caef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ pontos = ">=22.7,<24.0"
 codespell = "^2.0.0"
 python-magic = "^0.4.25"
 chardet = ">=4,<6"
-validators = ">=0.21.2,<0.23.0"
+validators = "0.20.0"
 gitpython = "^3.1.31"
 charset-normalizer = "^3.2.0"
 


### PR DESCRIPTION
## What
This PR downgrades `validators` to 0.20.0 after a version bump to a buggy version via #594.

## Why
To get rid off false positives. I checked every version, starting from the latest (0.22.0) and 0.20.0 was the first one with no false positives.

## References
This can be revered as soon as https://github.com/python-validators/validators/issues/296 is solved.

## Checklist
I ran the Troubadix against the affected NASL script and confirmed that there no longer is a false positive reported.