### PR TITLE
Change: Update dependabot.yml to prefix commits with Deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,12 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-
+    commit-message:
+      prefix: "Deps"


### PR DESCRIPTION
## What

Pontos introduced a new `Deps` conventional commit message type with greenbone/pontos#771 / DEVOPS-669 which will be put into a new `Dependencies` section in the generated changelog.

Current example dependabot config from Pontos (The `scope` seen in the PR above was removed again via greenbone/pontos#776) can be seen at e.g.:

https://github.com/greenbone/pontos/blob/main/.github/dependabot.yml

and the "outcome" here:

https://github.com/greenbone/pontos/releases/tag/v23.9.0

## Why

- To prevent empty releases with an empty Changelog like seen in e.g. https://github.com/greenbone/troubadix/releases/tag/v23.9.1
- Furthermore dependency updates might affect a specific release (e.g. if some issues got fixed in a dependency update or similar) and should be included in the Changelog

## References

Related to:
- greenbone/pontos#771
- DEVOPS-669