### PR TITLE
Change: Various updates for the conventional commits handling

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,15 +1,16 @@
 name: Conventional Commits
 
 on:
-  pull_request:
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+  contents: read
 
 jobs:
   conventional-commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: read
     steps:
       - name: Report Conventional Commits
         uses: greenbone/actions/conventional-commits@v3

--- a/changelog.toml
+++ b/changelog.toml
@@ -1,8 +1,0 @@
-commit_types = [
-    { message = "^add", group = "Added"},
-    { message = "^remove", group = "Removed"},
-    { message = "^change", group = "Changed"},
-    { message = "^fix", group = "Bug Fixes"},
-]
-
-changelog_dir = "changelog"


### PR DESCRIPTION
## What
- Update conventional-commits.yml to work with bot PRs
- Use default config for conventional commits

Use the same code / content as in e.g. https://github.com/greenbone/pontos/blob/main/.github/workflows/conventional-commits.yml which includes the updates from:
- greenbone/pontos#822
- greenbone/pontos#785

and also do the same as greenbone/pontos#793 to use the default config for conventional commits.

## Why

#616 is now prefixing all Dependabot PRs with `Deps:` to have them included in the changelog. But it seems the conventional-commits workflow wasn't able do identify these (probably because it wasn't able to get the data / info from the PR) and  thus only reported a `No conventional commits found.` like seen here:

https://github.com/greenbone/troubadix/pull/618#issuecomment-1718023674

while there actually was a conventional commit included in that PR.

This PR should make this to work.

## References

None