### PR TITLE
Change: Add additional valid URLs to script_xref() URL test.

### DIFF
--- a/tests/plugins/test_script_xref_url.py
+++ b/tests/plugins/test_script_xref_url.py
@@ -26,7 +26,31 @@ class CheckScriptXrefUrlTestCase(PluginTestCase):
     path = Path("some/file.nasl")
 
     def test_ok(self):
-        content = '  script_xref(name:"URL", value:"http://www.example.com");\n'
+        content = (
+            '  script_xref(name:"URL", value:"http://www.example.com");\n'
+            # pylint: disable=line-too-long
+            # Various cases from https://github.com/python-validators/validators/issues/296
+            '  script_xref(name:"URL", value:"https://launchpad.support.sap.com/#/notes/2718993");\n'
+            '  script_xref(name:"URL", value:"https://forums.livezilla.net/index.php?/topic/10983-fg-vd-19-086-livezilla-server-is-vulnerable-to-sql-injection-ii/");\n'
+            '  script_xref(name:"URL", value:"http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/security-bulletin/brocade-security-advisory-2016-168.pdf");\n'
+            '  script_xref(name:"URL", value:"https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-security/8SA-M3as7A8");\n'
+            '  script_xref(name:"URL", value:"https://forum.bitdefender.com/index.php?/topic/75470-doubleagent/");\n'
+            '  script_xref(name:"URL", value:"https://www.smartftp.com/forums/index.php?/topic/16425-smartftp-client-40-change-log/");\n'
+            '  script_xref(name:"URL", value:"https://exchange.xforce.ibmcloud.com/#/vulnerabilities/100912");\n'
+            '  script_xref(name:"URL", value:"https://support.microsoft.com/en-us/lifecycle#gp/Microsoft-Internet-Explorer");\n'
+            '  script_xref(name:"URL", value:"https://www.watchguard.com/support/release-notes/fireware/12/en-US/EN_ReleaseNotes_Fireware_12_5_9/index.html#Fireware/en-US/resolved_issues.html");\n'
+            '  script_xref(name:"URL", value:"https://code.wireshark.org/review/#/c/25660/");\n'
+            '  script_xref(name:"URL", value:"https://groups.google.com/forum/#!topic/kubernetes-announce/yBrFf5nmvfI");\n'
+            '  script_xref(name:"URL", value:"https://issues.sonatype.org/plugins/servlet/mobile#issue/NEXUS-16870");\n'
+            '  script_xref(name:"URL", value:"http://forums.livezilla.net/index.php?/topic/163-livezilla-changelog/");\n'
+            '  script_xref(name:"URL", value:"https://www.watchguard.com/support/release-notes/fireware/11/en-US/EN_ReleaseNotes_Fireware_11_12_1/index.html#Fireware/en-US/resolved_issues.html%3FTocPath%3D_____13");\n'
+            '  script_xref(name:"URL", value:"https://review.typo3.org/#/c/37013");\n'
+            '  script_xref(name:"URL", value:"https://forums.malwarebytes.org/index.php?/topic/158251-malwarebytes-anti-exploit-hall-of-fame/");\n'
+            '  script_xref(name:"URL", value:"http://speedtouch.sourceforge.io/index.php?/news.en.html");\n'
+            '  script_xref(name:"URL", value:"https://support.k7computing.com/index.php?/Knowledgebase/Article/View/173/41/advisory-issued-on-6th-november-2017");\n'
+            '  script_xref(name:"URL", value:"http://support.novell.com/cgi-bin/search/searchtid.cgi?/10077872.htm");\n'
+            # pylint: enable=line-too-long
+        )
         fake_context = self.create_file_plugin_context(
             nasl_file=self.path, file_content=content
         )


### PR DESCRIPTION
## What
Adds the valid URLs which i have identified / collected previously in:

https://github.com/python-validators/validators/issues/296#issuecomment-1708338654

## Why
To catch issues caused by dependency updates earlier (like happened via #594 and reverted afterwards via #609). This is important especially as we only had a very basic URL `http://www.example.com` in the current test.

## References
None directly

## Checklist
- [x] Tests


