### PR TITLE
Add: Groups for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       - dependency-type: indirect
     commit-message:
       prefix: "Deps"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -18,3 +22,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Deps"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
This PR adds groups for Dependabot PRs.

## Why
To only have a single PR with all updated packages instead of one PR per update.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


