### PR TITLE
Change: Add additional spelling exclusion

### DIFF
--- a/troubadix/plugins/spelling.py
+++ b/troubadix/plugins/spelling.py
@@ -92,7 +92,7 @@ exceptions = [
         r"alle|als|tage|lokale|uptodate|paket|titel|ba|"
         r"ordner|modul|interaktive|programm|explizit|"
         r"normale|applikation|attributen|lokal|signatur|"
-        r"modell|klick|generell)\s+==>\s+",
+        r"modell|klick|generell|vor)\s+==>\s+",
         re.IGNORECASE,
     ),
     # False positives in the gsf/PCIDSS and GSHB/ VTs:


### PR DESCRIPTION
## What
See title...

## Why
Prevent false positives for German text parts like e.g.:

> IT-Grundschutz M4.147: Sichere Nutzung von EFS unter Windows (Windows)

## References
None