### PR TITLE
Change: Add badwords plugin exclusion and sync codespell.ignore

### DIFF
--- a/troubadix/codespell/codespell.ignore
+++ b/troubadix/codespell/codespell.ignore
@@ -21,3 +21,8 @@ complies
 # we see a lot of false positives for the vulnerability. As we usually only have the vulnerability
 # mentioned here this correction is fully ingored.
 racoon
+# re-use vs. reuse currently unclear, e.g. there is the following from https://dict.leo.org/forum/viewGeneraldiscussion.php?idForum=4&idThread=5586&lp=ende&lang=en:
+# Not even the wise and educated English native speakers seem to have a rule on hyphenation and there are differences between BE and AE.
+# As e.g. the spelling correction in Mozilla Firefox is accepting both we're excluding this for now
+re-use
+re-usable

--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -90,7 +90,9 @@ EXCEPTIONS = [
     "gz3nvtPjk",  # Same as above
     "0EAnvtBAK",  # Same as above
     "technocrackers",  # Author name of a wordpress plugin
+    "Technocrackers",  # Author name of a wordpress plugin
     "firecracker",  # Valid package name on e.g. Fedora
+    "Firecracker",  # Valid package name on e.g. Fedora
 ]
 
 STARTS_WITH_EXCEPTIONS = [


### PR DESCRIPTION
## What
- Adds the uppercase variants of:
  - #634
  - #608
- Syncs the codespell.ignore with the productive repo

## Why
Avoid false positives

## References
None