### PR TITLE
Change: Various script_xref() related extensions / modifications.

### DIFF
--- a/tests/plugins/test_script_calls_empty_values.py
+++ b/tests/plugins/test_script_calls_empty_values.py
@@ -56,6 +56,7 @@ class CheckScriptCallsEmptyValuesTestCase(PluginTestCase):
         content = (
             '  script_category("");\n'
             '  script_xref(name: "URL",value:"");\n'
+            '  script_xref(name:"URL", value:"");\n'
             '  script_tag(name:"", value:"");\n'
         )
         fake_context = self.create_file_plugin_context(
@@ -65,5 +66,5 @@ class CheckScriptCallsEmptyValuesTestCase(PluginTestCase):
 
         results = list(plugin.run())
 
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         self.assertIsInstance(results[0], LinterError)

--- a/tests/plugins/test_script_tag_whitespaces.py
+++ b/tests/plugins/test_script_tag_whitespaces.py
@@ -32,6 +32,10 @@ class CheckScriptTagWhitespacesTestCase(PluginTestCase):
             '  script_tag(name:"insight", value:"bar foo");\n'
             '  script_tag(name:"impact", value:"- foo\n  - bar");\n'
             '  script_tag(name:"affected", value:"foo\n  bar");\n'
+            '  script_xref(name:"foo1", value:"foo\nbar");\n'
+            '  script_xref(name:"foo2", value:"bar foo");\n'
+            '  script_xref(name:"foo3", value:"- foo\n  - bar");\n'
+            '  script_xref(name:"foo4", value:"foo\n  bar");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=self.path, file_content=content
@@ -85,6 +89,23 @@ class CheckScriptTagWhitespacesTestCase(PluginTestCase):
             results[0].message,
         )
 
+    def test_script_xref_leading_whitespace(self):
+        content = '  script_xref(name:"foo", value:" bar");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptTagWhitespaces(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            'script_xref(name:"foo", value:" bar");: value contains a'
+            " leading or trailing whitespace character",
+            results[0].message,
+        )
+
     def test_script_tag_trailing_whitespace(self):
         content = '  script_tag(name:"insight", value:"bar ");\n'
         fake_context = self.create_file_plugin_context(
@@ -108,6 +129,23 @@ class CheckScriptTagWhitespacesTestCase(PluginTestCase):
 
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
+
+    def test_script_xref_trailing_whitespace(self):
+        content = '  script_xref(name:"foo", value:"bar ");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptTagWhitespaces(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            'script_xref(name:"foo", value:"bar ");: value contains a'
+            " leading or trailing whitespace character",
+            results[0].message,
+        )
 
     # nb: The script_name() tag is not allowed to contain newlines (checked in a
     # dedicated plugin) so no specific test cases have been added here.
@@ -149,6 +187,57 @@ class CheckScriptTagWhitespacesTestCase(PluginTestCase):
 
     def test_script_tag_trailing_newline_with_newline_and_spaces(self):
         content = '  script_tag(name:"insight", value:"foo\n  bar\n");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptTagWhitespaces(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+
+    # nb: The value of script_xref(name:"URL" are also checked separately in
+    # script_xref_url() and that one would also report trailing / leading
+    # newlines and similar for that specific case
+    def test_script_xref_trailing_newline(self):
+        content = '  script_xref(name:"foo", value:"bar\n");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptTagWhitespaces(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+
+    def test_script_xref_trailing_newline_with_space(self):
+        content = '  script_xref(name:"foo", value:"foo bar\n");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptTagWhitespaces(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+
+    def test_script_xref_trailing_newline_with_newline(self):
+        content = '  script_xref(name:"foo", value:"foo\nbar\n");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptTagWhitespaces(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+
+    def test_script_xref_trailing_newline_with_newline_and_spaces(self):
+        content = '  script_xref(name:"foo", value:"foo\n  bar\n");\n'
         fake_context = self.create_file_plugin_context(
             nasl_file=self.path, file_content=content
         )

--- a/tests/plugins/test_script_xref_form.py
+++ b/tests/plugins/test_script_xref_form.py
@@ -58,7 +58,7 @@ class CheckScriptXrefFormTestCase(PluginTestCase):
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             'script_xref(nammmme: "foo", value:"bar");: does not conform to'
-            ' script_xref(name:"<name>", value:<value>);',
+            ' script_xref(name:"<name>", value:"<value>");',
             results[0].message,
         )
 
@@ -76,6 +76,30 @@ class CheckScriptXrefFormTestCase(PluginTestCase):
 
     def test_wrong_missing_parameters(self):
         content = '  script_xref("foo", "bar");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptXrefForm(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+
+    def test_wrong_missing_name_parameter(self):
+        content = '  script_xref("foo", value:"bar");\n'
+        fake_context = self.create_file_plugin_context(
+            nasl_file=self.path, file_content=content
+        )
+        plugin = CheckScriptXrefForm(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+
+    def test_wrong_missing_value_parameter(self):
+        content = '  script_xref(name:"foo", "bar");\n'
         fake_context = self.create_file_plugin_context(
             nasl_file=self.path, file_content=content
         )

--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -178,12 +178,6 @@ _SPECIAL_TAG_PATTERN = (
     r"(?P=quote99)?\s*\)\s*;"
 )
 
-_XREF_TAG_PATTERN = (
-    r'script_xref\(\s*name\s*:\s*(?P<quote>[\'"])(?P<type>{type})'
-    r'(?P=quote)\s*,\s*value\s*:\s*(?P<quote2>[\'"])?(?P<value>{'
-    r"value})(?P=quote2)?\s*\)\s*;"
-)
-
 
 class SpecialScriptTag(Enum):
     ADD_PREFERENCE = "add_preference"

--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -143,7 +143,7 @@ def get_script_tag_pattern(script_tag: ScriptTag) -> re.Pattern:
 
 _XREF_TAG_PATTERN = (
     r'script_xref\(\s*name\s*:\s*(?P<quote>[\'"])(?P<name>{name})(?P=quote)\s*,'
-    r'\s*value\s*:\s*(?P<quote2>[\'"])?(?P<value>{value})(?P=quote2)?\s*\)\s*;'
+    r'\s*value\s*:\s*(?P<quote2>[\'"])(?P<value>{value})(?P=quote2)\s*\)\s*;'
 )
 
 

--- a/troubadix/helper/patterns.py
+++ b/troubadix/helper/patterns.py
@@ -142,33 +142,30 @@ def get_script_tag_pattern(script_tag: ScriptTag) -> re.Pattern:
 
 
 _XREF_TAG_PATTERN = (
-    r'script_xref\(\s*name\s*:\s*["\'](?P<type>{type})["\']\s*,'
-    r'\s*value\s*:\s*["\']?(?P<value>{value})["\']?\s*\)\s*;'
+    r'script_xref\(\s*name\s*:\s*(?P<quote>[\'"])(?P<name>{name})(?P=quote)\s*,'
+    r'\s*value\s*:\s*(?P<quote2>[\'"])?(?P<value>{value})(?P=quote2)?\s*\)\s*;'
 )
 
 
 def get_xref_pattern(
-    name: str,
-    *,
-    value: str = r".+",
-    flags: re.RegexFlag = 0,
+    name: str, *, value: str = r".+?", flags: re.RegexFlag = 0
 ) -> re.Pattern:
     """
     The returned pattern catches all
-    `script_xref(name="{type}", value="{value}");`
+    `script_xref(name="{name}", value="{value}");`
 
     Arguments:
-        name        script xref type e.g. URL
+        name        script xref name e.g. URL
         value       script tag value (default: at least one char)
         flags       regex flags for compile (default: 0)
 
     The returned `Match`s by this pattern will have group strings
-    .group('type') and .group('value')
+    .group('name') and .group('value')
     Returns
         `re.Pattern` object
     """
     return re.compile(
-        _XREF_TAG_PATTERN.format(type=name, value=value),
+        _XREF_TAG_PATTERN.format(name=name, value=value),
         flags=flags,
     )
 

--- a/troubadix/plugins/script_tag_whitespaces.py
+++ b/troubadix/plugins/script_tag_whitespaces.py
@@ -24,6 +24,7 @@ from troubadix.helper import SpecialScriptTag
 from troubadix.helper.patterns import (
     _get_special_script_tag_pattern,
     _get_tag_pattern,
+    get_xref_pattern,
 )
 from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
 
@@ -51,7 +52,11 @@ class CheckScriptTagWhitespaces(FileContentPlugin):
             name=SpecialScriptTag.NAME.value
         ).finditer(file_content)
 
-        matches = chain(tag_matches, name_matches)
+        xref_matches = get_xref_pattern(name=r".+?", flags=re.S).finditer(
+            file_content
+        )
+
+        matches = chain(tag_matches, name_matches, xref_matches)
 
         for match in matches:
             if re.match(r"^\s+.*", match.group("value")) or re.match(

--- a/troubadix/plugins/script_xref_form.py
+++ b/troubadix/plugins/script_xref_form.py
@@ -46,7 +46,7 @@ class CheckScriptXrefForm(FileContentPlugin):
                     ):
                         yield LinterError(
                             f"{match.group(0)}: does not conform to"
-                            ' script_xref(name:"<name>", value:<value>);',
+                            ' script_xref(name:"<name>", value:"<value>");',
                             file=nasl_file,
                             plugin=self.name,
                         )


### PR DESCRIPTION
## What
Note: #643 should be merged first to have it included in the next release as well

Extending the plugin accordingly to catch something like below seen in greenbone/vulnerability-tests#7373

```
  script_xref(name:"Policy", value:"CIS Microsoft Windows 10 Enterprise (Release 22H2) Benchmark v2.0.0: REMOVE - 2.3.17 (L1) Ensure 'User Account Control: Allow UIAccess applications to prompt for elevation without using the secure desktop' is set to 'Disabled' Ticket #8863 ");
```

Old QA step was able to catch this while the new Troubadix not because it seems there was no support for checking `script_xref()` tags within it.

While doing this i had also noticed that there were two `_XREF_TAG_PATTERN` defined and `get_xref_pattern` didn't worked as expected for the `script_tag_whitespaces.py` plugins so had to do some additional adjustments / updates.

## Why
Better/extended QA checks and more unit tests.

## References
None

## Checklist

- [x] Tests