### PR TITLE
Add: Exclude for http_links_in_tags check

### DIFF
--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -167,6 +167,7 @@ class CheckHttpLinksInTags(FilePlugin):
             "https:// ",
             "such as 'http://:80'",
             "<http://localhost/moodle/admin/>",
+            "https://username:password@proxy:8080",
         ]
 
         return any(


### PR DESCRIPTION
## What
This PR adds an exclude for the http_links_in_tags check.

## Why
Because https://github.com/greenbone/vulnerability-tests/actions/runs/8342778895/job/22831672387?pr=10122 is failing, e.g. for https://alas.aws.amazon.com/AL2/ALAS-2023-2110.html.

## References
Noticed during https://github.com/greenbone/vulnerability-tests/pull/10122.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


