### PR TITLE
Fix: Codecov in workflow

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -67,5 +67,5 @@ jobs:
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ inputs.token }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## What
This PR fixes Codecov in our workflow.

## Why
To have Codecov working again.
For whatever reason we already have `secrets.CODECOV_TOKEN` present, but we're not using it.

## References
This kind of error has been first introduced in https://github.com/greenbone/troubadix/pull/668, but can't really tell why. Also, the error got shadowed by another one, because in the CI runs prior to that one it also failed due to a different error.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


