### PR TITLE
Fix: Fix wrong Copyright year for new tests file.

### DIFF
--- a/tests/plugins/test_overlong_description_lines.py
+++ b/tests/plugins/test_overlong_description_lines.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022 Greenbone AG
+#  Copyright (c) 2024 Greenbone AG
 #
 #  SPDX-License-Identifier: GPL-3.0-or-later
 #


### PR DESCRIPTION
## What
This was newly introduced in / via #681 in 2024 but the wrong 2022 copyright year probably has been copied over from another one.

## Why
Obvious...

## References
Related to: VTOPS-174