### PR TITLE
Change: Add script_add_preference() as exclusion to overlong line plugin.

### DIFF
--- a/tests/plugins/test_overlong_description_lines.py
+++ b/tests/plugins/test_overlong_description_lines.py
@@ -37,6 +37,10 @@ class CheckOverlongDescriptionLinesTestCase(PluginTestCase):
             'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");\n'
             '  script_xref(name:"xref as well", value:"xxxxxxxxxxxxxx'
             'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");\n'
+            '  script_add_preference(name:"script_add_preference as well '
+            'xxxxxxxxxxxxxxxxxxxxxxx", type:"checkbox", value:"no", id:1);\n'
+            '  script_add_preference(type:"password", value:"", id:2, name:"'
+            'Another variant of script_add_preference xxxxxxxxxxxxxxxxxxxx");\n'
             "  exit(0);\n"
             "}\n"
             "ignored line that is not part of description"

--- a/troubadix/plugins/overlong_description_lines.py
+++ b/troubadix/plugins/overlong_description_lines.py
@@ -31,6 +31,7 @@ DESCRIPTION_END_PATTERN = re.compile(r"exit\(0\)")
 IGNORE_TAGS = [
     "script_name",
     "script_xref",
+    "script_add_preference",
 ]
 
 


### PR DESCRIPTION
## What
See title

## Why
Similar to the existing `script_name()` and `script_xref()` we can't have newlines in the name and/or value tag of `script_add_preference()` and should not do any any reporting for now.

## References
None specific

## Checklist
- [x] Tests


