### PR TITLE
Add: Exclusion to http_links_in_tags

### DIFF
--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -168,6 +168,7 @@ class CheckHttpLinksInTags(FilePlugin):
             "such as 'http://:80'",
             "<http://localhost/moodle/admin/>",
             "https://username:password@proxy:8080",
+            "sun.net.www.http.KeepAliveCache",
         ]
 
         return any(


### PR DESCRIPTION
## What
This PR adds an exclusion to the http_links_in_tags check.

## Why
To avoid a false-positive.

## References
Fixes https://github.com/greenbone/vulnerability-tests/pull/10815#issuecomment-2099813010.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


