### PR TITLE
Fix: Red Hat spelling

### DIFF
--- a/tests/plugins/test_valid_oid.py
+++ b/tests/plugins/test_valid_oid.py
@@ -520,7 +520,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         path = Path("some/file.nasl")
         content = (
             '  script_oid("1.3.6.1.4.1.25623.1.1.11.2256");\n'
-            '  script_family("RedHat Local Security Checks");\n'
+            '  script_family("Red Hat Local Security Checks");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content
@@ -550,7 +550,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         self.assertEqual(
             (
                 "script_oid() is using an OID that is reserved for "
-                "RedHat '1.3.6.1.4.1.25623.1.1.11.2256'"
+                "Red Hat '1.3.6.1.4.1.25623.1.1.11.2256'"
             ),
             results[0].message,
         )

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -265,9 +265,9 @@ class CheckValidOID(FileContentPlugin):
                 return
 
             elif vendor_number == "11":
-                if family != f"RedHat {family_template}":
+                if family != f"Red Hat {family_template}":
                     yield LinterError(
-                        f"script_oid() {is_using_reserved} RedHat "
+                        f"script_oid() {is_using_reserved} Red Hat "
                         f"'{str(oid)}'",
                         file=nasl_file,
                         plugin=self.name,


### PR DESCRIPTION
## What
This PR fixes the spelling of `Red Hat`.

## Why
Because we use the correct spelling `Red Hat` instead of `RedHat` in the upcoming VTs. Troubadix will fail otherwise.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


