### PR TITLE
Change: Add additional exclusion file name in two plugins.

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -39,6 +39,7 @@ DEFAULT_BADWORDS = [
 _IGNORE_FILES = [
     "gb_openvas",
     "gb_gsa_",
+    "gb_greenbone_gsa_",
     "http_func.inc",
     "misc_func.inc",
     "OpenVAS_detect.nasl",

--- a/troubadix/plugins/todo_tbd.py
+++ b/troubadix/plugins/todo_tbd.py
@@ -25,6 +25,7 @@ from ..plugin import LineContentPlugin, LinterResult, LinterWarning
 _IGNORE_FILES = [
     "gb_openvas",
     "gb_gsa_",
+    "gb_greenbone_gsa_",
     "http_func.inc",
     "misc_func.inc",
 ]


### PR DESCRIPTION
## What
`gb_gsa_detect.nasl` will be renamed to `gb_greenbone_gsa_http_detect.nasl` for consistency reasons in the PR below so we need to adjust / extend the file name exclusions here.

## Why
Required for: greenbone/vulnerability-tests#11394

## References
None