### PR TITLE
Fix: Usage of a wrong NASL syntax in one test.

### DIFF
--- a/tests/plugins/test_vt_placement.py
+++ b/tests/plugins/test_vt_placement.py
@@ -78,7 +78,7 @@ class CheckVTPlacementTestCase(PluginTestCase):
                     '  script_tag(name:"cvss_base", value:"4.0");\n'
                     '  script_tag(name:"summary", value:"Foo Bar.");\n'
                     f'  script_family("{_type} detection");\n'
-                    '  script_tag(name:"deprecated", value=TRUE);\n'
+                    '  script_tag(name:"deprecated", value:TRUE);\n'
                 )
 
                 fake_context = self.create_file_plugin_context(


### PR DESCRIPTION
## What
Syntax of such tags is:

```
script_tag(name:"foo", value:"bar");
```
and not:
```
script_tag(name:"foo", value="bar");
```

## Why
Obvious...

## References
None

## Checklist
- [x] Tests