### PR TITLE
Change: Extend the exclusion of overlong description lines. Adjust test.

### DIFF
--- a/tests/plugins/test_overlong_description_lines.py
+++ b/tests/plugins/test_overlong_description_lines.py
@@ -44,6 +44,9 @@ class CheckOverlongDescriptionLinesTestCase(PluginTestCase):
             'script_tag(name:"vuldetect", value:'
             '"Checks if a vulnerable version is present on the target host."'
             ");\n"
+            'script_tag(name:"vuldetect", value:'
+            '"Checks if a vulnerable OS build is present on the target host."'
+            ");\n"
             "  exit(0);\n"
             "}\n"
             "ignored line that is not part of description"

--- a/troubadix/plugins/overlong_description_lines.py
+++ b/troubadix/plugins/overlong_description_lines.py
@@ -32,9 +32,11 @@ IGNORE_TAGS = [
     "script_name",
     "script_xref",
     "script_add_preference",
-    # nb: Special case we should ignore (at least for now) as it is commonly
-    # used like this and is only two chars "too long".
+    # nb: Special cases we should ignore (at least for now) as these are
+    # commonly used like this and is only two chars "too long".
     'script_tag(name:"vuldetect", value:"Checks if a vulnerable version is '
+    + 'present on the target host.");',
+    'script_tag(name:"vuldetect", value:"Checks if a vulnerable OS build is '
     + 'present on the target host.");',
 ]
 


### PR DESCRIPTION
## What
Add an exclusion similar to #716 for the new plugin from #712

## Why
Prevents the reporting of something which won't be changed anytime soon.

## References
None

## Checklist
- [x] Tests


