### PR TITLE
Enable running with no config if no plugin needs a config

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -39,7 +39,7 @@ from troubadix.runner import Runner, TroubadixException
 
 _here = Path(__file__).parent
 
-DEFAULT_CONFIG = {}
+DEFAULT_CONFIG = Path("troubadix.toml")
 
 
 class TestRunner(unittest.TestCase):
@@ -53,7 +53,7 @@ class TestRunner(unittest.TestCase):
             n_jobs=1,
             reporter=self._reporter,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         plugins = _FILE_PLUGINS + _FILES_PLUGINS
@@ -76,7 +76,7 @@ class TestRunner(unittest.TestCase):
             reporter=self._reporter,
             excluded_plugins=excluded_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         for plugin in runner.plugins:
@@ -92,7 +92,7 @@ class TestRunner(unittest.TestCase):
             reporter=self._reporter,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         self.assertEqual(len(runner.plugins), 2)
@@ -118,7 +118,7 @@ class TestRunner(unittest.TestCase):
             reporter=self._reporter,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
         with redirect_stdout(io.StringIO()) as _:
             sys_exit = runner.run([nasl_file])
@@ -162,7 +162,7 @@ class TestRunner(unittest.TestCase):
             reporter=self._reporter,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         with redirect_stdout(io.StringIO()) as _:
@@ -211,7 +211,7 @@ class TestRunner(unittest.TestCase):
             reporter=reporter,
             included_plugins=[CheckScriptVersionAndLastModificationTags.name],
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         with redirect_stdout(io.StringIO()) as f:
@@ -258,7 +258,7 @@ class TestRunner(unittest.TestCase):
             reporter=reporter,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         with redirect_stdout(io.StringIO()) as f:
@@ -295,7 +295,7 @@ class TestRunner(unittest.TestCase):
             reporter=reporter,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         with redirect_stdout(io.StringIO()) as f:
@@ -335,7 +335,7 @@ class TestRunner(unittest.TestCase):
             n_jobs=1,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         with redirect_stdout(io.StringIO()) as f:
@@ -359,7 +359,7 @@ class TestRunner(unittest.TestCase):
             reporter=self._reporter,
             included_plugins=["foo"],
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         nasl_file = _here / "plugins" / "test.nasl"
@@ -392,7 +392,7 @@ class TestRunner(unittest.TestCase):
             n_jobs=1,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
         with redirect_stdout(io.StringIO()):
             runner.run([nasl_file])
@@ -440,7 +440,7 @@ class TestRunner(unittest.TestCase):
             reporter=reporter,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
         with redirect_stdout(io.StringIO()):
             runner.run([nasl_file])
@@ -478,7 +478,7 @@ class TestRunner(unittest.TestCase):
             included_plugins=included_plugins,
             root=self.root,
             ignore_warnings=True,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         with redirect_stdout(io.StringIO()) as f:
@@ -504,7 +504,7 @@ class TestRunner(unittest.TestCase):
             reporter=reporter,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
 
         with redirect_stdout(io.StringIO()) as f:
@@ -545,7 +545,7 @@ class TestRunner(unittest.TestCase):
             n_jobs=1,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
         with redirect_stdout(io.StringIO()):
             runner.run([nasl_file])
@@ -592,7 +592,7 @@ class TestRunner(unittest.TestCase):
             n_jobs=1,
             included_plugins=included_plugins,
             root=self.root,
-            plugins_config=DEFAULT_CONFIG,
+            plugins_config_path=DEFAULT_CONFIG,
         )
         with redirect_stdout(io.StringIO()):
             runner.run([nasl_file])

--- a/troubadix/argparser.py
+++ b/troubadix/argparser.py
@@ -235,15 +235,18 @@ def parse_args(
         help="Don't print the statistic",
     )
 
-    parser.add_argument(
+    config_group = parser.add_mutually_exclusive_group()
+    config_group.add_argument(
         "-c",
         "--config",
-        type=file_type,
+        type=Path,
         default="troubadix.toml",
-        help=(
-            "Specify the path to the file that contains additional "
-            "configuration for the plugins"
-        ),
+        help=("Path to the configuration file (default: config.toml)"),
+    )
+    config_group.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Run without a configuration file",
     )
 
     if not args:

--- a/troubadix/argparser.py
+++ b/troubadix/argparser.py
@@ -235,18 +235,15 @@ def parse_args(
         help="Don't print the statistic",
     )
 
-    config_group = parser.add_mutually_exclusive_group()
-    config_group.add_argument(
+    parser.add_argument(
         "-c",
         "--config",
         type=Path,
         default="troubadix.toml",
-        help=("Path to the configuration file (default: config.toml)"),
-    )
-    config_group.add_argument(
-        "--no-config",
-        action="store_true",
-        help="Run without a configuration file",
+        help=(
+            "Specify the path to the file that contains additional "
+            "configuration for the plugins"
+        ),
     )
 
     if not args:

--- a/troubadix/runner.py
+++ b/troubadix/runner.py
@@ -17,9 +17,10 @@
 
 import datetime
 import signal
+import sys
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 from troubadix.helper.patterns import (
     init_script_tag_patterns,
@@ -29,6 +30,11 @@ from troubadix.plugin import FilePluginContext, FilesPluginContext, Plugin
 from troubadix.plugins import StandardPlugins
 from troubadix.reporter import Reporter
 from troubadix.results import FileResults, Results
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 CHUNKSIZE = 1  # default 1
 
@@ -53,7 +59,7 @@ class Runner:
         included_plugins: Iterable[str] = None,
         fix: bool = False,
         ignore_warnings: bool = False,
-        plugins_config: dict,
+        plugins_config_path: Optional[Path],
     ) -> None:
         # plugins initialization
         self.plugins = StandardPlugins(excluded_plugins, included_plugins)
@@ -61,7 +67,25 @@ class Runner:
         self._excluded_plugins = excluded_plugins
         self._included_plugins = included_plugins
 
-        self.plugins_config = plugins_config
+        self.requires_config = self._check_requires_config()
+        if self.requires_config:
+            if plugins_config_path is None:
+                print(
+                    "Plugins are being run that require a external config file"
+                )
+                sys.exit(1)
+
+            # Get the plugins configurations from the external toml file
+            try:
+                with open(plugins_config_path, "rb") as file:
+                    self.plugins_config = tomllib.load(file)
+            except FileNotFoundError:
+                print(f"Config file '{plugins_config_path}' does not exist")
+                sys.exit(1)
+            except tomllib.TOMLDecodeError as e:
+                print(f"Error decoding TOML file '{plugins_config_path}': {e}")
+                sys.exit(1)
+
         self._reporter = reporter
         self._n_jobs = n_jobs
         self._root = root
@@ -109,6 +133,12 @@ class Runner:
             )
             for plugin_class in plugin_classes
         ]
+
+    def _check_requires_config(self):
+        return any(
+            plugin.require_external_config
+            for plugin in self.plugins.files_plugins + self.plugins.file_plugins
+        )
 
     def _run_pooled(self, files: Iterable[Path]):
         """Run all plugins that check single files"""

--- a/troubadix/runner.py
+++ b/troubadix/runner.py
@@ -20,7 +20,7 @@ import signal
 import sys
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable
 
 from troubadix.helper.patterns import (
     init_script_tag_patterns,
@@ -59,7 +59,7 @@ class Runner:
         included_plugins: Iterable[str] = None,
         fix: bool = False,
         ignore_warnings: bool = False,
-        plugins_config_path: Optional[Path],
+        plugins_config_path: Path,
     ) -> None:
         # plugins initialization
         self.plugins = StandardPlugins(excluded_plugins, included_plugins)
@@ -69,11 +69,6 @@ class Runner:
 
         self.requires_config = self._check_requires_config()
         if self.requires_config:
-            if plugins_config_path is None:
-                print(
-                    "Plugins are being run that require a external config file"
-                )
-                sys.exit(1)
 
             # Get the plugins configurations from the external toml file
             try:

--- a/troubadix/troubadix.py
+++ b/troubadix/troubadix.py
@@ -30,11 +30,6 @@ from troubadix.helper import get_root
 from troubadix.reporter import Reporter
 from troubadix.runner import Runner
 
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
-
 
 def generate_file_list(
     dirs: Iterable[Path],
@@ -168,13 +163,10 @@ def main(args=None):
         first_file = files[0].resolve()
         root = get_root(first_file)
 
-    # Get the plugins configurations from the external toml file
-    try:
-        with open(parsed_args.config, "rb") as file:
-            plugins_config = tomllib.load(file)
-    except FileNotFoundError:
-        term.warning(f"Config file '{parsed_args.config}' does not exist")
-        sys.exit(1)
+    if parsed_args.no_config:
+        config_path = None
+    else:
+        config_path = parsed_args.config
 
     reporter = Reporter(
         term=term,
@@ -195,7 +187,7 @@ def main(args=None):
         fix=parsed_args.fix,
         ignore_warnings=parsed_args.ignore_warnings,
         root=root,
-        plugins_config=plugins_config,
+        plugins_config_path=config_path,
     )
 
     term.info(f"Start linting {len(files)} files ... ")

--- a/troubadix/troubadix.py
+++ b/troubadix/troubadix.py
@@ -163,11 +163,6 @@ def main(args=None):
         first_file = files[0].resolve()
         root = get_root(first_file)
 
-    if parsed_args.no_config:
-        config_path = None
-    else:
-        config_path = parsed_args.config
-
     reporter = Reporter(
         term=term,
         fix=parsed_args.fix,
@@ -187,7 +182,7 @@ def main(args=None):
         fix=parsed_args.fix,
         ignore_warnings=parsed_args.ignore_warnings,
         root=root,
-        plugins_config_path=config_path,
+        plugins_config_path=parsed_args.config,
     )
 
     term.info(f"Start linting {len(files)} files ... ")


### PR DESCRIPTION
## What
Additional edits to [poc_plugins_config_file](https://github.com/greenbone/troubadix/pull/706). Allows Troubadix to run without a config file if no plugins require it. 
Checks if any of the plugins that are part of the current run need the config, and only then loads the toml file.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Alternative to placing an empty default config in the repo, so that Troubadix does not crash even if no config would have been required. Maintains the same level of security by not allowing plugins that require config to accidentally run without one.
<!-- Describe why are these changes necessary? -->

## Running Troubadix
### Ok
#### Only config free plugins:
with default config. `./troubadix.toml` can point to nothing or actual config
``
troubadix --include-tests <plugins_without_config> -d ~/gb/vulnerability-tests/nasl
``
manual config. Path can point to nothing or actual config
``
troubadix --include-tests <plugins_without_config> -d ~/gb/vulnerability-tests/nasl --config troubadix.toml
``
#### Plugins that require config
with default config when`./troubadix.toml` points to  actual config
`troubadix --include-tests <plugins_with_config> -d ~/gb/vulnerability-tests/nasl`
manual config and path points to actual config
``
troubadix --include-tests <plugins_with_config> -d ~/gb/vulnerability-tests/nasl --config troubadix.toml
``
### Not Ok
with default config if `./troubadix.toml` does not exist
`troubadix --include-tests <plugins_with_config> -d ~/gb/vulnerability-tests/nasl`
manual config and path pointing to non-existent file
``
troubadix --include-tests <plugins_with_config> -d ~/gb/vulnerability-tests/nasl --config fake_file
``
## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests





