### PR TITLE
Fix: Dependency-Review permission

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:


### PR DESCRIPTION
## What

Adds the `pull-request: write` permission to the Dependency-Review workflow so it stops failing

## Why

<!-- Describe why are these changes necessary? -->

## References

Closes: DOS-280

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


