### PR TITLE
Change: script_calls_recommended group2 regex to match multilne

### DIFF
--- a/tests/plugins/test_script_calls_recommended.py
+++ b/tests/plugins/test_script_calls_recommended.py
@@ -67,11 +67,10 @@ class CheckScriptCallsRecommendedTestCase(PluginTestCase):
 
     def test_dependencies_multiline(self):
         content = (
+            # tests group1
             '  script_dependencies("123",\n"456");\n'
-            "  script_require_ports();\n"
-            "  script_require_udp_ports();\n"
-            "  script_require_keys();\n"
-            "  script_mandatory_keys();\n"
+            # tests group2
+            '  script_mandatory_keys("foo",\n"bar");\n'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=self.path, file_content=content

--- a/troubadix/plugins/script_calls_recommended.py
+++ b/troubadix/plugins/script_calls_recommended.py
@@ -73,7 +73,9 @@ class CheckScriptCallsRecommended(FileContentPlugin):
         ]
 
         if not _get_special_script_tag_pattern(
-            name=rf"({'|'.join(recommended_many_call)})", value=".*"
+            name=rf"({'|'.join(recommended_many_call)})",
+            value=".*?",
+            flags=re.DOTALL,
         ).search(file_content):
             yield LinterWarning(
                 "VT contains none of the following recommended calls: "


### PR DESCRIPTION
## What

Fixes a bug in check_script_calls_recommended that gives a false positive that there is no group 2 tag in the VT when the script tag value spans multiple lines.

The tests did not catch this because they did not cover this case.
The regex now uses re.DOTALL.
The value pattern is changed to .*? to not over match when using the DOTALL flag.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

<!-- Describe why are these changes necessary? -->

## References
Jira VTOPS-220

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


