### PR TITLE
Change: Add exclusion to one standalone plugin.

### DIFF
--- a/troubadix/standalone_plugins/version_updated.py
+++ b/troubadix/standalone_plugins/version_updated.py
@@ -42,6 +42,7 @@ _IGNORE_FILES = [
     "policy_control_template.nasl",
     "test_version_func_inc.nasl",
     "test_ipv6_packet_forgery.nasl",
+    "test_http_extract_location_from_redirect.nasl",
 ]
 
 


### PR DESCRIPTION
## What
See title

## Why
Required for greenbone/vulnerability-tests#13527

## References
None