### PR TITLE
Change: Update validators

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -308,17 +308,6 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
-name = "decorator"
-version = "5.1.1"
-description = "Decorators for Humans"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
-    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
@@ -911,21 +900,19 @@ files = [
 
 [[package]]
 name = "validators"
-version = "0.20.0"
-description = "Python Data Validation for Humans™."
+version = "0.34.0"
+description = "Python Data Validation for Humans™"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=3.8"
 files = [
-    {file = "validators-0.20.0.tar.gz", hash = "sha256:24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a"},
+    {file = "validators-0.34.0-py3-none-any.whl", hash = "sha256:c804b476e3e6d3786fa07a30073a4ef694e617805eb1946ceee3fe5a9b8b1321"},
+    {file = "validators-0.34.0.tar.gz", hash = "sha256:647fe407b45af9a74d245b943b18e6a816acf4926974278f6dd617778e1e781f"},
 ]
 
-[package.dependencies]
-decorator = ">=3.4.0"
-
 [package.extras]
-test = ["flake8 (>=2.4.0)", "isort (>=4.2.2)", "pytest (>=2.2.3)"]
+crypto-eth-addresses = ["eth-hash[pycryptodome] (>=0.7.0)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3610b1fe63bb6da688c1d8f7e868b0855e904f216e996d0d4b64b9e276618acb"
+content-hash = "664daad3945668e9fff39a84c858b424e5561b6b50b8c1271bd102d6cc68b806"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pontos = ">=22.7,<25.0"
 codespell = "^2.0.0"
 python-magic = "^0.4.25"
 chardet = ">=4,<6"
-validators = "0.20.0"
+validators = "^0.34.0"
 gitpython = "^3.1.31"
 charset-normalizer = "^3.2.0"
 


### PR DESCRIPTION
## What
This PR updates the dependency validators.

## Why
We've locked validators to a fixed version in https://github.com/greenbone/troubadix/pull/609, but it's no longer necessary.

## References
Related to https://github.com/greenbone/troubadix/pull/609.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


