### PR TITLE
Change: Extend invalid URL plugin and relevant tests.

### DIFF
--- a/troubadix/plugins/script_xref_url.py
+++ b/troubadix/plugins/script_xref_url.py
@@ -41,6 +41,10 @@ ALLOWED_URLS = [
     "http://mail-archives.apache.org/mod_mbox/perl-advocacy/2"
     "00904.mbox/<ad28918e0904011458h273a71d4x408f1ed286c9dfbc@mail.gmail.com>",
     "http://yehg.net/lab/pr0js/advisories/[mybb1.6]_cross_site_scripting",
+    "http://www.live555.com/liveMedia/public/changelog.txt#[2021.08.04]",
+    "http://www.live555.com/liveMedia/public/changelog.txt#[2021.08.06]",
+    "http://www.live555.com/liveMedia/public/changelog.txt#[2021.08.09]",
+    "http://www.live555.com/liveMedia/public/changelog.txt#[2021.08.13]",
 ]
 
 


### PR DESCRIPTION
## What
- Adds more cases which should be detected which seems to be not covered by the validators package (yet)
- Excludes a few additional valid / allowed URLs which are now reported as invalid after the version bump of the validators package in #763

## Why
- To catch additional possible malformed URLs introduced by e.g. some automatic extraction or by copy'n'paste like seen / noticed in:
  - greenbone/vulnerability-tests#13985
  - greenbone/vulnerability-tests#13986
  - greenbone/vulnerability-tests#13953
  - greenbone/vulnerability-tests#13959
  - greenbone/vulnerability-tests#14055
- To exclude a few special URLs which seems to be valid but edge cases and reported as invalid by the validators package

## References
None

## Checklist
- [x] Tests


