### PR TITLE
Add: update valid_oid plugin for Windows

### DIFF
--- a/tests/plugins/test_valid_oid.py
+++ b/tests/plugins/test_valid_oid.py
@@ -26,7 +26,10 @@ from . import PluginTestCase
 class CheckValidOIDTestCase(PluginTestCase):
     def test_ok(self):
         path = Path("some/file.nasl")
-        content = '  script_oid("1.3.6.1.4.1.25623.1.0.100376");\n'
+        content = (
+            '  script_oid("1.3.6.1.4.1.25623.1.0.100376");\n'
+            '  script_family("Huawei EulerOS Local Security Checks");\n'
+        )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content
         )
@@ -764,6 +767,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         content = (
             '  script_oid("1.3.6.1.4.1.25623.1.2.1.2020.255");\n'
             '  script_name("Mozilla Firefox Security Advisory");\n'
+            '  script_family("General");'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content
@@ -779,6 +783,7 @@ class CheckValidOIDTestCase(PluginTestCase):
         content = (
             '  script_oid("1.3.6.1.4.1.25623.1.2.1.2020.255");\n'
             '  script_name("AdaptBB Detection (HTTP)");\n'
+            '  script_family("General");'
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=path, file_content=content

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -85,18 +85,17 @@ class CheckValidOID(FileContentPlugin):
         family_pattern = get_special_script_tag_pattern(SpecialScriptTag.FAMILY)
         family_match = family_pattern.search(file_content)
 
+        if family_match is None or family_match.group("value") is None:
+            yield LinterError(
+                "VT is missing a script family!",
+                file=nasl_file,
+                plugin=self.name,
+            )
+            return
+
         # Vendor-specific OIDs
         if "1.3.6.1.4.1.25623.1.1." in oid:
-            if family_match is None or family_match.group("value") is None:
-                yield LinterError(
-                    "VT is missing a script family!",
-                    file=nasl_file,
-                    plugin=self.name,
-                )
-                return
-
             family = family_match.group("value")
-
             vendor_number_match = re.search(
                 r"^1\.3\.6\.1\.4\.1\.25623\.1\.1\.([0-9]+)\.", oid
             )
@@ -389,14 +388,6 @@ class CheckValidOID(FileContentPlugin):
 
         # Fixed OID-scheme for Windows OIDs
         if "1.3.6.1.4.1.25623.1.3." in oid:
-            if not family_match or not family_match.group("value"):
-                yield LinterError(
-                    "VT is missing a script family!",
-                    file=nasl_file,
-                    plugin=self.name,
-                )
-                return
-
             if family_match.group("value") != windows_family_template:
                 yield LinterError(
                     f"script_oid() {is_using_reserved} 'Windows' ("


### PR DESCRIPTION
## What

Add validation for the generated windows NASL scripts.
Also add missing validation for upcoming  OpenSuse generator.

(The other new generators, HCE and openEuler, do not use NASL so Troubadix is irrelevant)

## Why

This check is currently failing while testing win-vt-generator.

## References

VTA-633

## Checklist

- [x] Tests


