### PR TITLE
Change: Extend ignore list of overlong description lines plugin. Adjust tests.

### DIFF
--- a/tests/plugins/test_overlong_description_lines.py
+++ b/tests/plugins/test_overlong_description_lines.py
@@ -25,7 +25,7 @@ from troubadix.plugins.overlong_description_lines import (
 
 
 class CheckOverlongDescriptionLinesTestCase(PluginTestCase):
-    def test_ok(self):
+    def test_ok_generic(self):
         nasl_file = Path(__file__).parent / "test.nasl"
         content = (
             "ignored line that is not part of description"
@@ -51,6 +51,30 @@ class CheckOverlongDescriptionLinesTestCase(PluginTestCase):
             "}\n"
             "ignored line that is not part of description"
             "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckOverlongDescriptionLines(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_ok_urls_in_comments(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            "if (description)\n"
+            "{\n"
+            '  script_version("2021-09-02T14:01:33+0000");\n'
+            "  # https://overlongurlisokxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");\n'
+            "  # > https://anothervariantwhichisokxxxxxxxxxxxxxxxxxxx"
+            'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");\n'
+            "  # - https://anothervariantwhichisalsookxxxxxxxxxxxxxxx"
+            'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");\n'
+            "  exit(0);\n"
+            "}\n"
         )
         fake_context = self.create_file_plugin_context(
             nasl_file=nasl_file, file_content=content

--- a/troubadix/plugins/overlong_description_lines.py
+++ b/troubadix/plugins/overlong_description_lines.py
@@ -32,6 +32,14 @@ IGNORE_TAGS = [
     "script_name",
     "script_xref",
     "script_add_preference",
+    # nb: Various variants of URLs in comments which we can't / shouldn't
+    # trim down
+    "  # http://",
+    "  # https://",
+    "  # - http://",
+    "  # - https://",
+    "  # > http://",
+    "  # > https://",
     # nb: Special cases we should ignore (at least for now) as these are
     # commonly used like this and is only two chars "too long".
     'script_tag(name:"vuldetect", value:"Checks if a vulnerable version is '


### PR DESCRIPTION
## What
See title

Note: No new release required, can be shipped / included in one of the next once more changes have happened to Troubadix.

## Why
Prevents some reporting similar to the `script_xref()` case for URLs we shouldn't break

## References
None

## Checklist
- [x] Tests


