### PR TITLE
Change: Fix NASL coding style output of deprecate VT plugin. Adjust test.

### DIFF
--- a/tests/standalone_plugins/test_deprecate_vts.py
+++ b/tests/standalone_plugins/test_deprecate_vts.py
@@ -189,7 +189,7 @@ class DeprecateVTsTestCase(unittest.TestCase):
         result = _finalize_content(NASL_CONTENT)
         expected = (
             '...if(description)\n{\n  script_oid("1.3.6.1.4.1.25623.1.0.910673");\n  '
-            'script_version("2024-03-12T14:15:13+0000");\n  script_name("RedHat: Security Advisory for gd (RHSA-2020:5443-01)");\n  script_family("Red Hat Local Security Checks");\n  script_dependencies("gather-package-list.nasl");\n  script_mandatory_keys("ssh/login/rhel", "ssh/login/rpms", re:"ssh/login/release=RHENT_7");\n\n  script_xref(name:"RHSA", value:"2020:5443-01");\n  script_xref(name:"URL", value:"https://www.redhat.com/archives/rhsa-announce/2020-December/msg00044.html");\n\n  script_tag(name:"summary", value:"The remote host is missing an update for the \'gd\'\n  package(s) announced via the RHSA-2020:5443-01 advisory.");\n\n  script_tag(name:"deprecated", value:TRUE);\n\nexit(0);\n}\n\nexit(66);\n'  # noqa: E501
+            'script_version("2024-03-12T14:15:13+0000");\n  script_name("RedHat: Security Advisory for gd (RHSA-2020:5443-01)");\n  script_family("Red Hat Local Security Checks");\n  script_dependencies("gather-package-list.nasl");\n  script_mandatory_keys("ssh/login/rhel", "ssh/login/rpms", re:"ssh/login/release=RHENT_7");\n\n  script_xref(name:"RHSA", value:"2020:5443-01");\n  script_xref(name:"URL", value:"https://www.redhat.com/archives/rhsa-announce/2020-December/msg00044.html");\n\n  script_tag(name:"summary", value:"The remote host is missing an update for the \'gd\'\n  package(s) announced via the RHSA-2020:5443-01 advisory.");\n\n  script_tag(name:"deprecated", value:TRUE);\n\n  exit(0);\n}\n\nexit(66);\n'  # noqa: E501
         )
         self.assertEqual(result, expected)
 

--- a/troubadix/standalone_plugins/deprecate_vts.py
+++ b/troubadix/standalone_plugins/deprecate_vts.py
@@ -81,7 +81,7 @@ def _finalize_content(content: str) -> str:
     content_to_keep = content.split("exit(0);")[0]
     return content_to_keep + (
         'script_tag(name:"deprecated", value:TRUE);'
-        "\n\nexit(0);\n}\n\nexit(66);\n"
+        "\n\n  exit(0);\n}\n\nexit(66);\n"
     )
 
 


### PR DESCRIPTION
## What
The plugin had created a coding style like e.g.:

```
  script_tag(name:"deprecated", value:TRUE);

exit(0);
}

exit(66);
```

and had missed to indent the `exit(0);` by two spaces. This is fixed now.

## Why
Have correct coding style / indentation in the NASL code

## References
greenbone/vulnerability-tests#15425 (Fixing all existing VTs which had that missing indentation originating from the previous version of this plugin)

## Checklist
- [x] Tests