### PR TITLE
Change: Pin non-Greenbone actions to commit hash

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -15,7 +15,7 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install and check with black, pylint and pontos.version
         uses: greenbone/actions/lint-python@v3
         with:
@@ -31,7 +31,7 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install python, poetry and dependencies
         uses: greenbone/actions/poetry@v3
         with:
@@ -46,7 +46,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install python, poetry and dependencies
         uses: greenbone/actions/poetry@v3
         with:
@@ -61,7 +61,7 @@ jobs:
       - name: Create coverage XML report
         run: poetry run coverage xml
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -35,6 +35,6 @@ jobs:
         queries: security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## What
As part of ongoing security updates, we are supposed to pin all non-greenbone actions to a commit hash.



## References
vta-608
https://confluence.greenbone.net/display/DEVOPS/Using+Actions+in+Workflows


