### PR TITLE
Add: openSUSE Local Security Checks family

### DIFF
--- a/troubadix/plugins/script_family.py
+++ b/troubadix/plugins/script_family.py
@@ -60,6 +60,7 @@ VALID_FAMILIES = [
     "Mandrake Local Security Checks",
     "Nmap NSE",
     "Nmap NSE net",
+    "openSUSE Local Security Checks",
     "Oracle Linux Local Security Checks",
     "PCI-DSS",
     "PCI-DSS 2.0",


### PR DESCRIPTION
## What
This PR adds the openSUSE Local Security Checks family

## Why
Because Notus is using a dedicated script family.

## References
Jira: VTA-660

## Checklist
Ran this against the NASL scripts with the new family