### PR TITLE
Add: line to codespell.exclude for opensuse

### DIFF
--- a/troubadix/codespell/codespell.exclude
+++ b/troubadix/codespell/codespell.exclude
@@ -1578,3 +1578,4 @@ xml += string( '<oval_system_characteristics xmlns="http://oval.mitre.org/XMLSch
   - XSS via a crafted WAN name on the General Setup screen (CVE-2019-16534)");
   "^[Xx]-[Aa]dobe-[Cc]ontent\s*:\s*AEM" );
   Zhongling Wen discovered that the h323 conntrack handler did not correctly
+    * CVE-2021-47311: net: qcom/emac: fix UAF in emac_remove (bsc#1225010).


### PR DESCRIPTION
## What

Exclude this line from an openSUSE VT due to a mistaken spelling error "emac" -> "emacs"

## Why

<!-- Describe why are these changes necessary? -->

## References

vta-597


