### PR TITLE
Add: Exception for bad words check

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -94,6 +94,7 @@ EXCEPTIONS = [
     "Technocrackers",  # Author name of a wordpress plugin
     "firecracker",  # Valid package name on e.g. Fedora
     "Firecracker",  # Valid package name on e.g. Fedora
+    "pcp-pmda-nutcracker",  # Valid package name on e.g. openSUSE or Arch Linux
 ]
 
 STARTS_WITH_EXCEPTIONS = [


### PR DESCRIPTION
## What
This PR adds an exception to the bad words check.

## Why
To pass https://github.com/greenbone/vulnerability-tests/actions/runs/13524409910/job/37791216439?pr=16543#step:14:1488.

## References
Required for https://github.com/greenbone/vulnerability-tests/pull/16543.

## Checklist
Ran Troubadix with these changes, now it's longer flagged.

