### PR TITLE
Add: Exception to bad words check

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -78,6 +78,7 @@ EXCEPTIONS = [
     "OpenVAS Administrator",
     "OpenVAS / Greenbone Vulnerability Manager",
     "openvas_1808149858",
+    "OSPD-OpenVAS",
     "evil.zip -> openvas.jsp",
     'url = "/openvas.jsp";',
     'if( "OpenVAS RCE Test" >< buf )',


### PR DESCRIPTION
## What
Adds an exception to the bad words check.

## Why
Required as a hint in a VT

## References
https://github.com/greenbone/vulnerability-tests/pull/16576

## Checklist
Manual run of troubadix and now it is no longer flagged


