### PR TITLE
Add: Check for creation date <= last modification date

### DIFF
--- a/tests/plugins/test_creation_date.py
+++ b/tests/plugins/test_creation_date.py
@@ -153,3 +153,43 @@ class CheckCreationDateTestCase(PluginTestCase):
             "False or incorrectly formatted creation_date.",
             results[0].message,
         )
+
+    def test_creation_date_greater_than_last_modification(self):
+        path = Path("some/file.nasl")
+        content = (
+            '  script_tag(name:"creation_date", value:"2025-01-01 00:00:01 '
+            '+0200 (Wed, 01 Jan 2025)");\n'
+            '  script_tag(name:"last_modification", value:"2025-01-01 00:00:00 '
+            '+0200 (Wed, 01 Jan 2025)");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content
+        )
+        plugin = CheckCreationDate(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "The creation_date must not be greater than the last modification date.",
+            results[0].message,
+        )
+
+    def test_creation_date_equal_last_modification(self):
+        path = Path("some/file.nasl")
+        content = (
+            '  script_tag(name:"creation_date", value:"2025-01-01 00:00:00 '
+            '+0200 (Wed, 01 Jan 2025)");\n'
+            '  script_tag(name:"last_modification", value:"2025-01-01 00:00:00 '
+            '+0200 (Wed, 01 Jan 2025)");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content
+        )
+        plugin = CheckCreationDate(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)

--- a/troubadix/plugins/creation_date.py
+++ b/troubadix/plugins/creation_date.py
@@ -94,3 +94,17 @@ class CheckCreationDate(FileContentPlugin):
                 file=nasl_file,
                 plugin=self.name,
             )
+
+        last_modification_pattern = get_script_tag_pattern(
+            ScriptTag.LAST_MODIFICATION
+        )
+        if match := last_modification_pattern.search(file_content):
+            last_modification = datetime.strptime(
+                match.group("value")[:25], "%Y-%m-%d %H:%M:%S %z"
+            )
+            if date_left > last_modification:
+                yield LinterError(
+                    "The creation_date must not be greater than the last modification date.",
+                    file=nasl_file,
+                    plugin=self.name,
+                )

--- a/troubadix/plugins/creation_date.py
+++ b/troubadix/plugins/creation_date.py
@@ -52,45 +52,45 @@ class CheckCreationDate(FileContentPlugin):
         # Example: "2017-11-29 13:56:41 +0100 (Wed, 29 Nov 2017)"
         match = tag_pattern.search(file_content)
 
-        if match:
-            try:
-                date_left = datetime.strptime(
-                    match.group("value")[:25], "%Y-%m-%d %H:%M:%S %z"
-                )
-                # 2017-11-29 13:56:41 +0100 (error if no timezone)
-                date_right = datetime.strptime(
-                    match.group("value")[27:43], "%a, %d %b %Y"
-                )
-                week_day_parsed = date_right.strftime("%a")
-            except ValueError:
-                yield LinterError(
-                    "False or incorrectly formatted creation_date.",
-                    file=nasl_file,
-                    plugin=self.name,
-                )
-                return
-
-            week_day_str = match.group("value")[27:30]
-            # Wed, 29 Nov 2017
-            if date_left.date() != date_right.date():
-                yield LinterError(
-                    "The creation_date consists of two different dates.",
-                    file=nasl_file,
-                    plugin=self.name,
-                )
-            # Check correct weekday
-            elif week_day_str != week_day_parsed:
-                formatted_date = week_day_parsed
-                yield LinterError(
-                    f"Wrong day of week. Please change it from '{week_day_str}"
-                    f"' to '{formatted_date}'.",
-                    file=nasl_file,
-                    plugin=self.name,
-                )
-        else:
+        if not match:
             yield LinterError(
                 "False or incorrectly formatted creation_date.",
                 file=nasl_file,
                 plugin=self.name,
             )
             return
+
+        try:
+            date_left = datetime.strptime(
+                match.group("value")[:25], "%Y-%m-%d %H:%M:%S %z"
+            )
+            # 2017-11-29 13:56:41 +0100 (error if no timezone)
+            date_right = datetime.strptime(
+                match.group("value")[27:43], "%a, %d %b %Y"
+            )
+            week_day_parsed = date_right.strftime("%a")
+        except ValueError:
+            yield LinterError(
+                "False or incorrectly formatted creation_date.",
+                file=nasl_file,
+                plugin=self.name,
+            )
+            return
+
+        week_day_str = match.group("value")[27:30]
+        # Wed, 29 Nov 2017
+        if date_left.date() != date_right.date():
+            yield LinterError(
+                "The creation_date consists of two different dates.",
+                file=nasl_file,
+                plugin=self.name,
+            )
+        # Check correct weekday
+        elif week_day_str != week_day_parsed:
+            formatted_date = week_day_parsed
+            yield LinterError(
+                f"Wrong day of week. Please change it from '{week_day_str}"
+                f"' to '{formatted_date}'.",
+                file=nasl_file,
+                plugin=self.name,
+            )


### PR DESCRIPTION
## What
This PR adds a check to the creation date check to check whether the `creation_date` is smaller than / equal `last_modification`

## Why
Because a VT cannot be modified before it has been created.

## References
Jira: VTOPS-210
Depends on: greenbone/vulnerability-tests#16642

## Checklist
- [x] Tests