### PR TITLE
Change: Add additional unit test cases for date relevant plugins.

### DIFF
--- a/tests/plugins/test_creation_date.py
+++ b/tests/plugins/test_creation_date.py
@@ -193,3 +193,66 @@ class CheckCreationDateTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 0)
+
+    def test_malformed_hour(self):
+        path = Path("some/file.nasl")
+        content = (
+            '  script_tag(name:"creation_date", value:"2013-05-14 111:24:55 '
+            '+0200 (Tue, 14 May 2013)");\n'
+        )
+        fake_context = MagicMock()
+        fake_context.nasl_file = path
+        fake_context.file_content = content
+        plugin = CheckCreationDate(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "False or incorrectly formatted creation_date.",
+            results[0].message,
+        )
+
+    def test_malformed_second(self):
+        path = Path("some/file.nasl")
+        content = (
+            '  script_tag(name:"creation_date", value:"2013-05-14 11:24:55s '
+            '+0200 (Tue, 14 May 2013)");\n'
+        )
+        fake_context = MagicMock()
+        fake_context.nasl_file = path
+        fake_context.file_content = content
+        plugin = CheckCreationDate(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "False or incorrectly formatted creation_date.",
+            results[0].message,
+        )
+
+    def test_malformed_day(self):
+        path = Path("some/file.nasl")
+        content = (
+            '  script_tag(name:"creation_date", value:"2013-05-14D 11:24:55 '
+            '+0200 (Tue, 14 May 2013)");\n'
+        )
+        fake_context = MagicMock()
+        fake_context.nasl_file = path
+        fake_context.file_content = content
+        plugin = CheckCreationDate(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "False or incorrectly formatted creation_date.",
+            results[0].message,
+        )

--- a/tests/plugins/test_script_version_and_last_modification_tags.py
+++ b/tests/plugins/test_script_version_and_last_modification_tags.py
@@ -230,3 +230,63 @@ class CheckScriptVersionAndLastModificationTagsTestCase(PluginTestCase):
             "Wrong day of week. Please change it from 'Tue' to 'Mon'.",
             results[0].message,
         )
+
+    def test_modification_date_malformed_hour(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            '  script_version("2021-07-19T12:32:02+0000");\n'
+            '  script_tag(name:"last_modification", value:"2021-07-19 '
+            '112:32:02 +0000 (Mon, 19 Jul 2021");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckScriptVersionAndLastModificationTags(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(1, len(results))
+        self.assertEqual(
+            "False or incorrectly formatted modification_date.",
+            results[0].message,
+        )
+
+    def test_modification_date_malformed_second(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            '  script_version("2021-07-19T12:32:02+0000");\n'
+            '  script_tag(name:"last_modification", value:"2021-07-19 '
+            '12:32:02s +0000 (Mon, 19 Jul 2021");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckScriptVersionAndLastModificationTags(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(1, len(results))
+        self.assertEqual(
+            "False or incorrectly formatted modification_date.",
+            results[0].message,
+        )
+
+    def test_modification_date_malformed_day(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            '  script_version("2021-07-19T12:32:02+0000");\n'
+            '  script_tag(name:"last_modification", value:"2021-07-19D '
+            '12:32:02 +0000 (Mon, 19 Jul 2021");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckScriptVersionAndLastModificationTags(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(1, len(results))
+        self.assertEqual(
+            "False or incorrectly formatted modification_date.",
+            results[0].message,
+        )


### PR DESCRIPTION
## What
Adds relevant test cases which have been seen "live" in the past.

Notes:
- I have left out the cases for `script_version()` as this tag will be gone in the future anyway and is currently only kept for compatibility reasons with already EOL software versions
- No new release required, can be shipped with one of the next ones

## Why
Catch more cases

## References
VTOPS-202

## Checklist
- [x] Tests


