### PR TITLE
Change: Update/extend valid OID ranges.

### DIFF
--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -450,10 +450,7 @@ class CheckValidOID(FileContentPlugin):
 
         if (
             (10000 <= oid_digit <= 29999)
-            or (50000 <= oid_digit <= 118999)
-            or (120000 <= oid_digit <= 129999)
-            or (130000 <= oid_digit <= 169999)
-            or (170000 <= oid_digit <= 179999)
+            or (50000 <= oid_digit <= 179999)
             or (200000 <= oid_digit <= 209999)
             or (700000 <= oid_digit <= 919999)
             or (1020000 <= oid_digit <= 1029999)


### PR DESCRIPTION
## What
- See title
- As the OID range `50000` through `179999` is now assigned we can use a single check for these

## Why
- OID range `119NNN` got assigned recently and needs to be allowed
- Required for: greenbone/vulnerability-tests#18251

## References
None