### PR TITLE
Add: check for if_statement syntax

### DIFF
--- a/tests/plugins/test_if_statement_syntax.py
+++ b/tests/plugins/test_if_statement_syntax.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 Greenbone AG
+
+import unittest
+from pathlib import Path
+
+from troubadix.plugins.if_statement_syntax import CheckIfStatementSyntax
+
+from . import PluginTestCase
+
+
+class CheckIfStatementSyntaxTestCase(PluginTestCase):
+    """Test cases for the CheckIfStatementSyntax plugin."""
+
+    def test_valid_if_statements(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        if(condition) {
+            display("block statement");
+        }
+
+        if(another_condition) display("single statement");
+
+        if(nested_condition) {
+            if(inner_condition) {
+                display("nested");
+            }
+        }
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_unclosed_parenthesis(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        if(unclosed_condition {
+            display("this should fail");
+        }
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("Unclosed parenthesis", results[0].message)
+        self.assertIn("line 2", results[0].message)
+
+    def test_unclosed_brace(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        if(condition) {
+            display("missing closing brace");
+        # Missing closing brace
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("Unclosed brace", results[0].message)
+
+    def test_missing_statement(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        if(condition)
+        # No statement follows
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("Missing statement", results[0].message)
+
+    def test_semicolon_after_condition(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        if(condition);
+        {
+            display("this will always execute");
+        }
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("Semicolon after if condition", results[0].message)
+
+    def test_missing_semicolon_in_expression(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        if(condition) display("missing semicolon")
+        # No semicolon at end of expression
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("Missing expression", results[0].message)
+
+    def test_comment_handling(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        # This comment has an unclosed if(condition that should be ignored
+        if(real_condition) {
+            # Another comment with if(fake
+            display("real code");
+        }
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_complex_nested_error(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = """
+        if(outer_condition) {
+            if(inner_condition {  # Missing closing parenthesis
+                display("nested error");
+            }
+        }
+        """
+
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckIfStatementSyntax(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("Unclosed parenthesis", results[0].message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/troubadix/plugins/__init__.py
+++ b/troubadix/plugins/__init__.py
@@ -39,6 +39,7 @@ from .forking_nasl_functions import CheckForkingNaslFunctions
 from .get_kb_on_services import CheckGetKBOnServices
 from .grammar import CheckGrammar
 from .http_links_in_tags import CheckHttpLinksInTags
+from .if_statement_syntax import CheckIfStatementSyntax
 from .illegal_characters import CheckIllegalCharacters
 from .log_messages import CheckLogMessages
 from .malformed_dependencies import CheckMalformedDependencies
@@ -143,6 +144,7 @@ _FILE_PLUGINS = [
     CheckVTPlacement,
     CheckWrongSetGetKBCalls,
     CheckSpacesBeforeDots,
+    CheckIfStatementSyntax,
 ]
 
 # plugins checking all files

--- a/troubadix/plugins/if_statement_syntax.py
+++ b/troubadix/plugins/if_statement_syntax.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 Greenbone AG
+
+
+from pathlib import Path
+from typing import Iterator
+
+from troubadix.helper.if_block_parser import find_if_statements
+from troubadix.helper.remove_comments import remove_comments
+from troubadix.plugin import FileContentPlugin, LinterError, LinterResult
+
+
+class CheckIfStatementSyntax(FileContentPlugin):
+    """Check for syntax errors in if statements.
+
+    This plugin uses the if statement parser to detect common syntax errors such as:
+    - Unclosed parentheses in if conditions
+    - Unclosed braces in if blocks
+    - Missing statements after if conditions
+    - Semicolons after if conditions (which make following blocks always execute)
+    - Missing semicolons in single-line expressions
+    """
+
+    name = "check_if_statement_syntax"
+
+    def check_content(
+        self,
+        nasl_file: Path,
+        file_content: str,
+    ) -> Iterator[LinterResult]:
+        """Check the file content for if statement syntax errors."""
+        # Remove comments to avoid false positives from commented code
+        comment_free_content = remove_comments(file_content)
+
+        try:
+            find_if_statements(comment_free_content)
+        except ValueError as e:
+            yield LinterError(
+                f"If statement syntax error: {str(e)}",
+                file=nasl_file,
+                plugin=self.name,
+            )


### PR DESCRIPTION
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->
Adds a dedicated check for the if_statement syntax using the if_parser. By creating a dedicated check the using_display check can exit early if no display calls were found instead of still continuing to parse all if_statements.
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


