### PR TITLE
Change: Add exclusion to HTTP link check plugin.

### DIFF
--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -169,6 +169,9 @@ class CheckHttpLinksInTags(FilePlugin):
             "https://username:password@proxy:8080",
             "sun.net.www.http.KeepAliveCache",
             "www.foo.com",
+            # e.g.:
+            # sun.net.www.protocol.jar.JarURLConnection
+            "sun.net.www.",
         ]
 
         return any(


### PR DESCRIPTION
## What
See title

Note: Should be merged after #846 so that both are included in a new release.

## Why
To prevent false positives seen here:
- greenbone/vulnerability-tests#20278
- greenbone/vulnerability-tests#20285

## References
N/A