### PR TITLE
Change: Generally exclude URLs (http/https) in Badword plugin.

### DIFF
--- a/tests/plugins/test_badwords.py
+++ b/tests/plugins/test_badwords.py
@@ -67,7 +67,10 @@ class TestBadwords(PluginTestCase):
 
     def test_exception_ok(self):
         path = Path("some/include.inc")
-        content = '# HostDetails/NVT                 => "1.2.3.4"'
+        content = (
+            '# HostDetails/NVT                 => "1.2.3.4"\n'
+            "https://www.invt.com/software-download\n"
+        )
 
         fake_context = self.create_file_plugin_context(
             nasl_file=path, lines=content.splitlines()

--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -96,6 +96,10 @@ EXCEPTIONS = [
     "firecracker",  # Valid package name on e.g. Fedora
     "Firecracker",  # Valid package name on e.g. Fedora
     "pcp-pmda-nutcracker",  # Valid package name on e.g. openSUSE or Arch Linux
+    # We should generally exclude http:// and https:// URLs as these are
+    # immutable and shouldn't be changed / require separate exclusions for each
+    "https://",
+    "http://",
 ]
 
 STARTS_WITH_EXCEPTIONS = [


### PR DESCRIPTION
## What
Notes:
- We should generally exclude `http://` and `https://` URLs as these are immutable and shouldn't be changed / require separate exclusions for each
- No dedicated release required IMHO, can be shipped with the next release

## Why
Initially wanted to include this URL in greenbone/vulnerability-tests#20688 but the check failed.

## References
None

## Checklist
- [x] Tests


