### PR TITLE
Change: Various valid OID plugin and dependencies tests updates.

### DIFF
--- a/tests/plugins/test_dependencies.py
+++ b/tests/plugins/test_dependencies.py
@@ -93,16 +93,16 @@ class CheckDependenciesTestCase(PluginTestCase):
             results[0].message,
         )
 
-    def test_enterprise_dependency(self):
+    def test_gsf_dependency(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "enterprise" / "example.inc"
+            example = tmpdir / "common" / "gsf" / "example.inc"
             example.parent.mkdir(parents=True)
             example.touch()
             content = (
                 '  script_tag(name:"cvss_base", value:"4.0");\n'
                 '  script_tag(name:"summary", value:"Foo Bar...");\n'
-                '  script_dependencies("enterprise/example.inc");\n'
+                '  script_dependencies("gsf/example.inc");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -426,8 +426,6 @@ class CheckValidOID(FileContentPlugin):
             "ossim_server_detect.nasl",
             "gsf/2018/vmware/gb_vmware_fusion_vmxnet3_"
             "stack_memory_usage_vuln_macosx.nasl",
-            "enterprise/2018/vmware/gb_vmware_fusion_vmxnet3_"
-            "stack_memory_usage_vuln_macosx.nasl",
             "2008/asterisk_sdp_header_overflow.nasl",
             "2008/cisco_ios_ftp_server_auth_bypass.nasl",
             "2008/qk_smtp_server_dos.nasl",

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -425,7 +425,7 @@ class CheckValidOID(FileContentPlugin):
         exceptions = [
             "ossim_server_detect.nasl",
             "gsf/2018/vmware/gb_vmware_fusion_vmxnet3_"
-            "stack_memory_usage_vuln_macosx.nasl",
+            + "stack_memory_usage_vuln_macosx.nasl",
             "2008/asterisk_sdp_header_overflow.nasl",
             "2008/cisco_ios_ftp_server_auth_bypass.nasl",
             "2008/qk_smtp_server_dos.nasl",


### PR DESCRIPTION
## What
- Drop or replace "enterprise" folder as only "gsf" is currently used
- Use `+` to join a string instead of implicit string concatenation

Notes:
- It seems it was planned in the past to use `/enterprise` for a folder but this was never put into production. So just let us use the current `/gsf`
- No dedicated release required, this can be shipped with the next one
- This also solves the following two CodeQL suggestions:
  - https://github.com/greenbone/troubadix/security/code-scanning/17
  - https://github.com/greenbone/troubadix/security/code-scanning/16

## Why
Reflect reality and solves two additional CodeQL suggestions as a bonus.

## References
None

## Checklist
- [x] Tests


