### PR TITLE
Change: Fix various tests to use .nasl instead of .inc files.

### DIFF
--- a/tests/plugins/test_dependencies.py
+++ b/tests/plugins/test_dependencies.py
@@ -53,13 +53,13 @@ class CheckDependenciesTestCase(PluginTestCase):
     def test_dependency_existing(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "example.inc"
+            example = tmpdir / "common" / "example.nasl"
             example.parent.mkdir(parents=True)
             example.touch()
             content = (
                 '  script_tag(name:"cvss_base", value:"4.0");\n'
                 '  script_tag(name:"summary", value:"Foo Bar...");\n'
-                '  script_dependencies("example.inc");\n'
+                '  script_dependencies("example.nasl");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir
@@ -71,7 +71,7 @@ class CheckDependenciesTestCase(PluginTestCase):
             self.assertEqual(len(results), 0)
 
     def test_dependency_missing(self):
-        dependency = "example2.inc"
+        dependency = "example2.nasl"
         path = here / "file.nasl"
         content = (
             '  script_tag(name:"cvss_base", value:"4.0");\n'
@@ -96,13 +96,13 @@ class CheckDependenciesTestCase(PluginTestCase):
     def test_gsf_dependency(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "gsf" / "example.inc"
+            example = tmpdir / "common" / "gsf" / "example.nasl"
             example.parent.mkdir(parents=True)
             example.touch()
             content = (
                 '  script_tag(name:"cvss_base", value:"4.0");\n'
                 '  script_tag(name:"summary", value:"Foo Bar...");\n'
-                '  script_dependencies("gsf/example.inc");\n'
+                '  script_dependencies("gsf/example.nasl");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir
@@ -116,13 +116,13 @@ class CheckDependenciesTestCase(PluginTestCase):
     def test_policy_warning(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "Policy" / "example.inc"
+            example = tmpdir / "common" / "Policy" / "example.nasl"
             example.parent.mkdir(parents=True)
             example.touch()
             content = (
                 '  script_tag(name:"cvss_base", value:"4.0");\n'
                 '  script_tag(name:"summary", value:"Foo Bar...");\n'
-                '  script_dependencies("Policy/example.inc");\n'
+                '  script_dependencies("Policy/example.nasl");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir
@@ -135,7 +135,7 @@ class CheckDependenciesTestCase(PluginTestCase):
 
             self.assertIsInstance(results[0], LinterWarning)
             self.assertEqual(
-                "The script dependency Policy/example.inc is in a "
+                "The script dependency Policy/example.nasl is in a "
                 "subdirectory, which might be misplaced.",
                 results[0].message,
             )
@@ -143,13 +143,13 @@ class CheckDependenciesTestCase(PluginTestCase):
     def test_error(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "foo" / "example.inc"
+            example = tmpdir / "common" / "foo" / "example.nasl"
             example.parent.mkdir(parents=True)
             example.touch()
             content = (
                 '  script_tag(name:"cvss_base", value:"4.0");\n'
                 '  script_tag(name:"summary", value:"Foo Bar...");\n'
-                '  script_dependencies("foo/example.inc");\n'
+                '  script_dependencies("foo/example.nasl");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir
@@ -162,7 +162,7 @@ class CheckDependenciesTestCase(PluginTestCase):
 
             self.assertIsInstance(results[0], LinterError)
             self.assertEqual(
-                "The script dependency foo/example.inc is within a "
+                "The script dependency foo/example.nasl is within a "
                 "subdirectory, which is not allowed.",
                 results[0].message,
             )
@@ -170,13 +170,13 @@ class CheckDependenciesTestCase(PluginTestCase):
     def test_dependency_missing_newline(self):
         with self.create_directory() as tmpdir:
             path = tmpdir / "file.nasl"
-            example = tmpdir / "common" / "example.inc"
+            example = tmpdir / "common" / "example.nasl"
             example.parent.mkdir(parents=True)
             example.touch()
             content = (
                 '  script_tag(name:"cvss_base", value:"4.0");\n'
                 '  script_tag(name:"summary", value:"Foo Bar...");\n'
-                '  script_dependencies("example.inc", \n"example2.inc");\n'
+                '  script_dependencies("example.nasl", \n"example2.nasl");\n'
             )
             fake_context = self.create_file_plugin_context(
                 nasl_file=path, file_content=content, root=tmpdir
@@ -188,7 +188,7 @@ class CheckDependenciesTestCase(PluginTestCase):
             self.assertEqual(len(results), 1)
             self.assertIsInstance(results[0], LinterError)
             self.assertEqual(
-                "The script dependency example2.inc could "
+                "The script dependency example2.nasl could "
                 "not be found within the VTs.",
                 results[0].message,
             )

--- a/tests/plugins/test_dependency_category_order.py
+++ b/tests/plugins/test_dependency_category_order.py
@@ -31,7 +31,7 @@ class CheckDependencyCategoryOrderTestCase(PluginTestCase):
         self.tempdir = TemporaryDirectory()
         self.dir = Path(self.tempdir) / "foo"
         self.dir.mkdir(parents=True)
-        self.dep = self.dir / "example.inc"
+        self.dep = self.dir / "example.nasl"
         self.dep.write_text(
             "  script_category(ACT_ATTACK);", encoding=CURRENT_ENCODING
         )
@@ -74,12 +74,12 @@ class CheckDependencyCategoryOrderTestCase(PluginTestCase):
         self.assertEqual(len(results), 0)
 
     def test_dependency_missing(self):
-        dependency = "example2.inc"
+        dependency = "example2.nasl"
         path = self.dir / "file.nasl"
         content = (
             '  script_tag(name:"cvss_base", value:"4.0");\n'
             '  script_tag(name:"summary", value:"Foo Bar...");\n'
-            '  script_dependencies("example2.inc");\n'
+            '  script_dependencies("example2.nasl");\n'
             "  script_category(ACT_SCANNER);\n"
         )
         fake_context = self.create_file_plugin_context(
@@ -102,7 +102,7 @@ class CheckDependencyCategoryOrderTestCase(PluginTestCase):
         content = (
             '  script_tag(name:"cvss_base", value:"4.0");\n'
             '  script_tag(name:"summary", value:"Foo Bar...");\n'
-            '  script_dependencies("example.inc");\n'
+            '  script_dependencies("example.nasl");\n'
             "  script_category(ACT_SCANNER);\n"
         )
         fake_context = self.create_file_plugin_context(
@@ -116,12 +116,12 @@ class CheckDependencyCategoryOrderTestCase(PluginTestCase):
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
             "Script category ACT_SCANNER(1) is lower than the category "
-            "ACT_ATTACK(4) of the dependency example.inc.",
+            "ACT_ATTACK(4) of the dependency example.nasl.",
             results[0].message,
         )
 
     def test_category_missing(self):
-        dependency = "example.inc"
+        dependency = "example.nasl"
         path = self.dir / "file.nasl"
         content = (
             '  script_tag(name:"cvss_base", value:"4.0");\n'
@@ -147,7 +147,7 @@ class CheckDependencyCategoryOrderTestCase(PluginTestCase):
         content = (
             '  script_tag(name:"cvss_base", value:"4.0");\n'
             '  script_tag(name:"summary", value:"Foo Bar...");\n'
-            '  script_dependencies("example.inc");\n'
+            '  script_dependencies("example.nasl");\n'
             "  script_category(ACT_FOO);\n"
         )
         fake_context = self.create_file_plugin_context(

--- a/tests/plugins/test_deprecated_dependency.py
+++ b/tests/plugins/test_deprecated_dependency.py
@@ -29,7 +29,7 @@ class CheckDeprecatedDependencyTestCase(PluginTestCase):
         self.tempdir = TemporaryDirectory()
         self.dir = Path(self.tempdir) / "foo"
         self.dir.mkdir(parents=True)
-        self.dep = self.dir / "example.inc"
+        self.dep = self.dir / "example.nasl"
         self.dep.write_text(
             "  script_category(ACT_ATTACK);\n  exit(66);",
             encoding=CURRENT_ENCODING,
@@ -116,12 +116,12 @@ class CheckDeprecatedDependencyTestCase(PluginTestCase):
         self.assertEqual(len(results), 0)
 
     def test_dependency_missing(self):
-        dependency = "example2.inc"
+        dependency = "example2.nasl"
         path = self.dir / "file.nasl"
         content = (
             '  script_tag(name:"cvss_base", value:"4.0");\n'
             '  script_tag(name:"summary", value:"Foo Bar...");\n'
-            '  script_dependencies("example2.inc");\n'
+            '  script_dependencies("example2.nasl");\n'
             "  script_category(ACT_SCANNER);\n"
         )
 
@@ -145,7 +145,7 @@ class CheckDeprecatedDependencyTestCase(PluginTestCase):
         content = (
             '  script_tag(name:"cvss_base", value:"4.0");\n'
             '  script_tag(name:"summary", value:"Foo Bar...");\n'
-            '  script_dependencies("example.inc");\n'
+            '  script_dependencies("example.nasl");\n'
             "  script_category(ACT_SCANNER);\n"
         )
 
@@ -159,6 +159,6 @@ class CheckDeprecatedDependencyTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT depends on example.inc, which is marked as deprecated.",
+            "VT depends on example.nasl, which is marked as deprecated.",
             results[0].message,
         )

--- a/tests/plugins/test_vt_placement.py
+++ b/tests/plugins/test_vt_placement.py
@@ -96,7 +96,7 @@ class CheckVTPlacementTestCase(PluginTestCase):
             content = (
                 '  script_tag(name:"cvss_base", value:"4.0");\n'
                 '  script_tag(name:"summary", value:"Foo Bar...");\n'
-                '  script_dependencies("example.inc");\n'
+                '  script_dependencies("example.nasl");\n'
             )
 
             fake_context = self.create_file_plugin_context(


### PR DESCRIPTION
## What
Various tests had e.g. used `script_dependencies("example.inc");` but `.inc` files can only be used in `include()` calls so fix all (hope i found all so far) accordingly.

Note: No new release required, i will do another PR later today and do a release afterwards.

## Why
Use correct NASL code.

## References
None

## Checklist
- [x] Tests


