### PR TITLE
Change: Exclude grammar FP and adjust unit test.

### DIFF
--- a/tests/plugins/test_grammar.py
+++ b/tests/plugins/test_grammar.py
@@ -31,6 +31,10 @@ class CheckNewlinesTestCase(PluginTestCase):
             '  script_tag(name:"summary", value:"Foo Bar.");\n'
             '  script_tag(name:"vuldetect", value:"Sends multiple HTTP GET '
             'requests and checks the responses.");\n'
+            '  script_tag(name:"insight", value:"Determine which file systems '
+            "do not need to be supported based on the actual scenario and "
+            "disable mounting for these file systems through "
+            'configuration.");\n'
             '  script_tag(name:"solution_type", value:"VendorFix");\n'
             '  script_tag(name:"solution", value:"meh");\n'
         )

--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -56,7 +56,7 @@ exceptions = [
         r"these\s+error\s+(messages|reports|conditions)", re.IGNORECASE
     ),
     PatternCheck(
-        r"these\s+file\s+(permissions|overwrites|names|includes)",
+        r"these\s+file\s+(permissions|overwrites|names|includes|systems)",
         re.IGNORECASE,
     ),
     # nb: Valid sentence


### PR DESCRIPTION
## What
As reported by @hubert-kijowski

```
common/Policy/Euler/ensure_that_mounting_for_unnecessary_file_system_is_removed.nasl (4/5)
ℹ     Results for plugin check_grammar
×         VT/Include has the following grammar problem: mounting for these file systems through configuration. The following file systems are not commonly
```

## Why
Exclude a false positive

## References
None

## Checklist
- [x] Tests


