### PR TITLE
Change: Exclude certain CPE from Badchars check

### DIFF
--- a/troubadix/plugins/badwords.py
+++ b/troubadix/plugins/badwords.py
@@ -86,6 +86,7 @@ EXCEPTIONS = [
     "/var/lib/openvas/plugins/",
     "INVT ",  # INVT Electric VT Designer
     "invt_",  # cpe:/a:invt_electric
+    "cpe:/a:invt:", # cpe:/a:invt:vt-designer
     "HostDetails/NVT",  # Can't be changed right now...
     ", nvt:",  # Can't be changed right now...
     "Hu1nvt5qm",  # Part of a bigger blob


### PR DESCRIPTION
## What

Exclude certain CPE from badchars check as seen in https://github.com/greenbone/vulnerability-tests/pull/20844

## Why

Exclude valid CPE to allow QA run successfully.

## References

https://github.com/greenbone/vulnerability-tests/actions/runs/17421969591/job/49461980971



