### PR TITLE
Change: Exclude a grammar false positive and add a relevant test.

### DIFF
--- a/tests/plugins/test_grammar.py
+++ b/tests/plugins/test_grammar.py
@@ -327,3 +327,21 @@ class CheckNewlinesTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 0)
+
+    def test_grammar_fp2(self):
+        nasl_file = Path(__file__).parent / "test.nasl"
+        content = (
+            '  script_tag(name:"cvss_base", value:"4.0");\n'
+            '  script_tag(name:"insight", value:"Nadav Markus and Or Cohen of '
+            "Palo Alto Networks discovered\n"
+            '  script_tag(name:"solution_type", value:"VendorFix");\n'
+            '  script_tag(name:"solution", value:"meh");\n'
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=nasl_file, file_content=content
+        )
+        plugin = CheckGrammar(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)

--- a/troubadix/plugins/grammar.py
+++ b/troubadix/plugins/grammar.py
@@ -110,6 +110,8 @@ exceptions = [
     # The default has been changed to prompt the user each time a website
     # requests a client certificate.
     TextCheck("a website requests a client certificate"),
+    # This is actually a given name
+    TextCheck("and Or Cohen"),
 ]
 
 


### PR DESCRIPTION
## What
Short follow-up to #862 to exclude a false positive reported now.

## Why
Exclude e.g. this:

```
ℹ Checking 2021/debian/deb_dla_2690.nasl (74795/120871)
ℹ     Results for plugin check_grammar
×         VT/Include has the following grammar problem: CVE-2020-25670, CVE-2020
          -25671, CVE-2021-23134 kiyin (Yin Liang ) of TenCent discovered severa
          l reference counting bugs in the NFC LLCP implementation which could l
          ead to use-after-free. A local user could exploit these for denial of 
          service (crash or memory corruption) or possibly for privilege escalat
          ion. Nadav Markus and Or Cohen of Palo Alto Networks discovered that t
          he original fixes for these introduced a new bug that could result in 
          use-after-free and double-free. This has also been fixed.
```

## References
None

## Checklist
- [x] Tests