### PR TITLE
Change: script_add_preference_type regex

### DIFF
--- a/tests/plugins/test_script_add_preference_type.py
+++ b/tests/plugins/test_script_add_preference_type.py
@@ -89,9 +89,35 @@ class CheckScriptAddPreferenceTypeTestCase(PluginTestCase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], LinterError)
         self.assertEqual(
-            "VT is using an invalid or misspelled string (invalid)"
-            " passed to the type parameter of "
-            "script_add_preference in "
-            f"'{add_pref}'",
+            "VT is using an invalid or misspelled type "
+            f"(invalid) in {add_pref} \n"
+            f"Allowed are: {[t.value for t in ValidType]}",
+            results[0].message,
+        )
+
+    def test_invalid_with_parameters_order(self):
+        add_pref = (
+            'script_add_preference(name:"File or Directory Name", '
+            'type:"string", value:"/home", id:1);'
+        )
+        path = Path("some/file.nasl")
+        content = (
+            '  script_tag(name:"cvss_base", value:"4.0");\n'
+            '  script_name("Foo Bar");\n'
+            f"{add_pref}\n"
+        )
+        fake_context = self.create_file_plugin_context(
+            nasl_file=path, file_content=content
+        )
+        plugin = CheckScriptAddPreferenceType(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            "VT is using an invalid or misspelled type "
+            f"(string) in {add_pref} \n"
+            f"Allowed are: {[t.value for t in ValidType]}",
             results[0].message,
         )


### PR DESCRIPTION
## What
Splits regex for detecting a script_add_preference_call and for extracting the type into 2 separate parts. To make it simpler to:
- return an error if a function call is found but type extraction failed. No more quiet failing
- find the type parameter irrespective of its order in the function call.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
A pr introduced a file with a false negative that then crashed feed deployment.
<!-- Describe why are these changes necessary? -->

## References
Jira VTOPS-317
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ x] Tests


