### PR TITLE
Update Greenbone license header

### DIFF
--- a/tests/plugins/test_files/fail_name_and_copyright_newline.nasl
+++ b/tests/plugins/test_files/fail_name_and_copyright_newline.nasl
@@ -35,7 +35,7 @@ if(description)
   ction");
   script_category(ACT_GATHER_INFO);
   script_copyright("Copyright (c) Greenbone
-   Networks GmbH");
+   AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/21.04/fail.nasl
+++ b/tests/plugins/test_files/nasl/21.04/fail.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -32,7 +32,7 @@ if(description)
   script_cve_id("CVE-2011-12345", "CVE-2011-54321");
   script_name("foo detection");
   script_category(ACT_GATHER_INFO);
-  script_copyright("Copyright (c) Greenbone Networks GmbH");
+  script_copyright("Copyright (c) Greenbone AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/21.04/fail_name_and_copyright_newline.nasl
+++ b/tests/plugins/test_files/nasl/21.04/fail_name_and_copyright_newline.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ if(description)
   ction");
   script_category(ACT_GATHER_INFO);
   script_copyright("Copyright (c) Greenbone
-   Networks GmbH");
+   AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/21.04/fail_name_newline.nasl
+++ b/tests/plugins/test_files/nasl/21.04/fail_name_newline.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -34,7 +34,7 @@ if(description)
   script_name("foo 
   detection");
   script_category(ACT_GATHER_INFO);
-  script_copyright("Copyright (c) Greenbone Networks GmbH");
+  script_copyright("Copyright (c) Greenbone AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/21.04/fail_solution_template.nasl
+++ b/tests/plugins/test_files/nasl/21.04/fail_solution_template.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ if(description)
   script_cve_id("CVE-2011-12345", "CVE-2011-54321");
   script_name("foo detection");
   script_category(ACT_GATHER_INFO);
-  script_copyright("Copyright (c) Greenbone Networks GmbH");
+  script_copyright("Copyright (c) Greenbone AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/21.04/runner/fail.nasl
+++ b/tests/plugins/test_files/nasl/21.04/runner/fail.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/tests/plugins/test_files/nasl/21.04/runner/fail2.nasl
+++ b/tests/plugins/test_files/nasl/21.04/runner/fail2.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/tests/plugins/test_files/nasl/21.04/runner/test.nasl
+++ b/tests/plugins/test_files/nasl/21.04/runner/test.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ if(description)
   script_cve_id("CVE-2011-12345", "CVE-2011-54321");
   script_name("foo detection");
   script_category(ACT_GATHER_INFO);
-  script_copyright("Copyright (c) Greenbone Networks GmbH");
+  script_copyright("Copyright (c) Greenbone AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/21.04/runner/test_valid_oid.nasl
+++ b/tests/plugins/test_files/nasl/21.04/runner/test_valid_oid.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ if(description)
   script_cve_id("CVE-2011-12345", "CVE-2011-54321");
   script_name("foo detection");
   script_category(ACT_GATHER_INFO);
-  script_copyright("Copyright (c) Greenbone Networks GmbH");
+  script_copyright("Copyright (c) Greenbone AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/21.04/test.inc
+++ b/tests/plugins/test_files/nasl/21.04/test.inc
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/tests/plugins/test_files/nasl/21.04/test.nasl
+++ b/tests/plugins/test_files/nasl/21.04/test.nasl
@@ -7,7 +7,7 @@
 # Dr. Who <dr@who.org>
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016 Greenbone AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ if(description)
   script_cve_id("CVE-2011-12345", "CVE-2011-54321");
   script_name("foo detection");
   script_category(ACT_GATHER_INFO);
-  script_copyright("Copyright (c) Greenbone Networks GmbH");
+  script_copyright("Copyright (c) Greenbone AG");
   script_family("FreeBSD Local Security Checks");
   script_dependencies("gather-package-list.nasl");
   script_mandatory_keys("foo/bar", "bar/baz");

--- a/tests/plugins/test_files/nasl/warning.nasl
+++ b/tests/plugins/test_files/nasl/warning.nasl
@@ -9,7 +9,7 @@ if(description)
   script_tag(name:"last_modification", value:"2021-03-02 10:48:07 +0000 (Tue, 02 Mar 2021)");
   script_tag(name:"creation_date", value:"2017-02-27 11:48:20 +0100 (Mon, 27 Feb 2017)");
   script_name("Apache HTTP Server End of Life (EOL) Detection (Windows)");
-  script_copyright("Copyright (C) 2017 Greenbone Networks GmbH");
+  script_copyright("Copyright (C) 2017 Greenbone AG");
   script_category(ACT_GATHER_INFO);
   script_family("Web Servers");
   script_dependencies("gb_apache_http_server_consolidation.nasl", "os_detection.nasl");


### PR DESCRIPTION
## What

The old header was being used in some files (mostly unit test related), this PR updates those.

## Why
Cleaning out old backlog tickets/tasks

## References

VTOPS-3
