### PR TITLE
Change: Use multi-ecosystem Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,27 @@
 version: 2
-updates:
-  - package-ecosystem: pip
-    directory: "/"
+multi-ecosystem-groups:
+  dependencies:
     schedule:
       interval: weekly
       time: "04:00"
+    commit-message:
+      prefix: "Deps"
+
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies
     open-pull-requests-limit: 10
     allow:
       - dependency-type: direct
       - dependency-type: indirect
-    commit-message:
-      prefix: "Deps"
-    groups:
-      python-packages:
-        patterns:
-          - "*"
+
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "Deps"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies
+


### PR DESCRIPTION
## What
This PR changes Dependabot to use multi-ecosystem in a single PR.

Jira: https://jira.greenbone.net/browse/VTA-933
## Why
See ticket.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests