### PR TITLE
Remove: open-pull-requests-limit from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: dependencies
-    open-pull-requests-limit: 10
     allow:
       - dependency-type: direct
       - dependency-type: indirect


### PR DESCRIPTION
## What
This PR fixes https://github.com/greenbone/troubadix/pull/952

## Why
Because `"open-pull-requests-limit" should only be set on the associated multi-ecosystem group, not directly on updates that are part of a multi-ecosystem update group.`.
Instead of moving it to the multi-ecosystem group level, I decided to drop it, because it was added back when we weren't grouping per ecosystem so had one PR per e.g. Python package in https://github.com/greenbone/troubadix/blob/c81962370c3fa13252485ce990f534a7ee7e3ed2/.github/dependabot.yml.
Since this is no longer the case and were far from 10 open Dependabot PRs, I decided to drop this.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


