### PR TITLE
Change: Enable git rename detection

### DIFF
--- a/troubadix/standalone_plugins/community_entries.py
+++ b/troubadix/standalone_plugins/community_entries.py
@@ -70,7 +70,6 @@ def execute_git_diff(arguments: Namespace) -> list[str]:
         arguments.ref_from,
         "--name-only",
         "--diff-filter=A",
-        "--no-renames",
         "--",
         *file_extension_wildcards,
     ).splitlines()


### PR DESCRIPTION
## What
Enables git rename detection so that moved or renamed files do not get treated as deleted+added, resulting into only truly new files showing up in the git diff.

## References
VTOPS-356