### PR TITLE
Add: Fortinet oid check

### DIFF
--- a/tests/plugins/test_valid_oid.py
+++ b/tests/plugins/test_valid_oid.py
@@ -895,3 +895,39 @@ class CheckValidOIDTestCase(PluginTestCase):
         results = list(plugin.run())
 
         self.assertEqual(len(results), 0)
+
+    def test_script_name__product_fortinet_ok(self):
+        path = Path("some/file.nasl")
+        content = (
+            '  script_oid("1.3.6.1.4.1.25623.1.2.2.2.23.490");\n'
+            '  script_name("Fortinet Security Advisory");\n'
+            '  script_family("FortiOS Local Security Checks");'
+        )
+        fake_context = self.create_file_plugin_context(nasl_file=path, file_content=content)
+        plugin = CheckValidOID(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 0)
+
+    def test_script_name__product_fortinet(self):
+        path = Path("some/file.nasl")
+        content = (
+            '  script_oid("1.3.6.1.4.1.25623.1.2.2.23.490");\n'
+            '  script_name("Fortinet Security Advisory");\n'
+            '  script_family("General");'
+        )
+        fake_context = self.create_file_plugin_context(nasl_file=path, file_content=content)
+        plugin = CheckValidOID(fake_context)
+
+        results = list(plugin.run())
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], LinterError)
+        self.assertEqual(
+            (
+                "script_oid() is using an OID that is reserved for 'Fortinet' "
+                "(1.3.6.1.4.1.25623.1.2.2.23.490)"
+            ),
+            results[0].message,
+        )

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -357,6 +357,32 @@ class CheckValidOID(FileContentPlugin):
 
                 return
 
+            # Fixed OID-scheme for Fortinet OIDs
+            if "1.3.6.1.4.1.25623.1.2.2." in oid:
+                if family_match.group("value") != f"FortiOS {family_template}":
+                    yield LinterError(
+                        f"script_oid() {is_using_reserved} 'Fortinet' ({str(oid)})",
+                        file=nasl_file,
+                        plugin=self.name,
+                    )
+                    return
+
+                fortinet_sa_match = re.search(
+                    r"^1\.3\.6\.1\.4\.1\.25623\.1\.2\.2\.[0-9]+\.[0-9]{2}\.[0-9]+",
+                    oid,
+                )
+                if not fortinet_sa_match:
+                    yield LinterError(
+                        f"script_oid() {invalid_oid} '{str(oid)}' "
+                        "(Fortinet pattern: 1.3.6.1.4.1.25623.1.2.2.[PRODUCT_ID]."
+                        "[ADVISORY_YEAR].[ADVISORY_ID])",
+                        file=nasl_file,
+                        plugin=self.name,
+                    )
+                    return
+
+                return
+
         # Fixed OID-scheme for Windows OIDs
         if "1.3.6.1.4.1.25623.1.3." in oid:
             if family_match.group("value") != f"Windows {family_template}":


### PR DESCRIPTION
## What

Add a statement to handle the notus-generated oids for Fortinet.

## Why
troubadix checks were failing when the new notus fortinet generator was tried for the first time


## References

vta-983

## Checklist


- [x] Tests


