### PR TITLE
Change: Add 190xxx as valid OID range

### DIFF
--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -466,8 +466,7 @@ class CheckValidOID(FileContentPlugin):
 
         if (
             (10000 <= oid_digit <= 29999)
-            or (50000 <= oid_digit <= 189999)
-            or (200000 <= oid_digit <= 209999)
+            or (50000 <= oid_digit <=  209999)
             or (700000 <= oid_digit <= 919999)
             or (1020000 <= oid_digit <= 1029999)
         ):

--- a/troubadix/plugins/valid_oid.py
+++ b/troubadix/plugins/valid_oid.py
@@ -466,7 +466,7 @@ class CheckValidOID(FileContentPlugin):
 
         if (
             (10000 <= oid_digit <= 29999)
-            or (50000 <= oid_digit <=  209999)
+            or (50000 <= oid_digit <= 209999)
             or (700000 <= oid_digit <= 919999)
             or (1020000 <= oid_digit <= 1029999)
         ):


### PR DESCRIPTION
## What
* Adds 19xxxx as valid OIDs
* Since now at the lower bound of the next checked range, simplified
* Not sure if needs official Git release to trigger a change in workflows.

## Why

* I'm pretty much out of OIDs

## References

* Confluence assignment is updated

## Checklist